### PR TITLE
feat: upload Go release binaries to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,10 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: go build -trimpath -ldflags="-s -w" -o ./dist/${{ matrix.asset_name }} ./cmd/ghevents
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload asset to GitHub Release
+        uses: actions/upload-release-asset@v3
         with:
-          name: ${{ matrix.asset_name }}
-          path: ./dist/${{ matrix.asset_name }}
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/${{ matrix.asset_name }}
+          asset_name: ${{ matrix.asset_name }}
+          asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ go build -o ./bin/ghevents ./cmd/ghevents
 go test ./...
 ```
 
+## Release automation (Go release assets)
+
+- The release workflow builds binaries for configured platforms and attaches them to the GitHub Release as downloadable assets:
+- linux/amd64: ghevents-linux-amd64
+- darwin/amd64: ghevents-darwin-amd64
+- darwin/arm64: ghevents-darwin-arm64
+- windows/amd64: ghevents-windows-amd64.exe
+- These assets are uploaded automatically when a release is created on main.
+
 ## Design notes
 
 - The CLI uses the GitHub GraphQL API to preserve the existing event categories and output shape.


### PR DESCRIPTION
## Summary
- update the Go release workflow to attach built platform binaries directly to the GitHub Release
- replace workflow-artifact upload with release-asset upload using the release upload URL
- document the release asset behavior in README

## Testing
- `go test ./... -count=1`
- `go build -o ./bin/ghevents ./cmd/ghevents`
