### PR TITLE
chore: add contributor setup task

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,25 @@ This produces either `./exports/activity.json` or, when splitting is needed, fil
 
 ## Development setup
 
-This repository uses `mise` to install toolchain dependencies.
+This repository uses `mise` for contributor setup and toolchain management.
 
-Install the pinned tools:
+Recommended first command for contributors:
+
+```bash
+mise run setup
+```
+
+`mise run setup` keeps local setup to one command by:
+
+- installing the pinned tools with `mise install`
+- running `go mod tidy` to sync Go module dependencies
+- installing the local git hooks with `lefthook install`
+
+If you need to run the steps manually:
 
 ```bash
 mise install
-```
-
-Install git hooks:
-
-```bash
+go mod tidy
 lefthook install
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -9,3 +9,11 @@ pnpm = "10.28.1"
 python = "3"
 rust = "latest"
 uv = "latest"
+
+[tasks.setup]
+description = "Install tools, tidy Go modules, and install git hooks"
+run = """
+mise install
+go mod tidy
+lefthook install
+"""


### PR DESCRIPTION
## Summary
- add a `mise run setup` task for contributor onboarding
- make the setup task run `mise install`, `go mod tidy`, and `lefthook install`
- document the setup command in README as the recommended first step

## Validation
- mise run setup
- go test ./...
- go build -o ./bin/ghactivities ./cmd/ghactivities