### PR TITLE
chore: update devcontainer and tooling configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24
+FROM node:26
 
 ARG TZ
 ENV TZ="$TZ"
@@ -119,9 +119,9 @@ RUN curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/
 
 # Install global packages
 ENV PNPM_HOME=/home/node/.pnpm
-ENV PATH=$PATH:$PNPM_HOME
+ENV npm_config_registry=https://npm.flatt.tech/
+ENV PATH=$PNPM_HOME/bin:$PATH
 RUN mkdir -p "$PNPM_HOME" && \
-    mise exec -- pnpm setup && \
     mise exec -- pnpm add -g \
     @openai/codex \
     @google/gemini-cli
@@ -132,6 +132,13 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # Install OpenCode
 RUN curl -fsSL https://opencode.ai/install | bash
 RUN echo 'PATH=/home/node/.opencode/bin:$PATH' >> "/home/node/.bashrc"
+
+# Install git-gtr
+RUN mkdir -p /home/node/.local/bin /home/node/.local/src && \
+    git clone https://github.com/coderabbitai/git-worktree-runner /home/node/.local/src/git-worktree-runner && \
+    ln -s /home/node/.local/src/git-worktree-runner/bin/git-gtr /home/node/.local/bin/git-gtr && \
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "/home/node/.bashrc" && \
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "/home/node/.zshrc"
 
 # Aliases
 ENV CLAUDE_COMMAND="alias claude=\"claude --dangerously-skip-permissions\""

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,13 +10,10 @@
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "customizations": {
     "vscode": {
-      "extensions": ["oxc.oxc-vscode", "dbaeumer.vscode-eslint", "eamodio.gitlens"],
+      "extensions": ["oxc.oxc-vscode", "eamodio.gitlens"],
       "settings": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "oxc.oxc-vscode",
-        "editor.codeActionsOnSave": {
-          "source.fixAll.eslint": "explicit"
-        },
         "oxc.enable": true,
         "oxc.fmt.experimental": true,
         "terminal.integrated.defaultProfile.linux": "zsh",
@@ -37,17 +34,20 @@
     "source=${localWorkspaceFolderBasename}-claude-code-bashhistory,target=/commandhistory,type=volume,consistency=delegated",
     "source=${localWorkspaceFolderBasename}-claude-code-config,target=/home/node/.claude,type=volume,consistency=delegated",
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume,consistency=delegated",
-    "source=${localWorkspaceFolderBasename}-pnpm-store,target=${containerWorkspaceFolder}/.pnpm-store,type=volume,consistency=delegated"
+    "source=${localWorkspaceFolderBasename}-pnpm-store,target=/home/node/.pnpm-store,type=volume,consistency=delegated",
+    "source=${localWorkspaceFolderBasename}-workspace-worktrees,target=/workspace-worktrees,type=volume,consistency=delegated",
+    "source=${localWorkspaceFolderBasename}-local-share-opencode,target=/home/node/.local/share/opencode,type=volume,consistency=delegated"
   ],
   "remoteEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "GITHUB_TOKEN": "${localEnv:DEVCONTAINER_GITHUB_TOKEN}",
-    "OPENAI_API_KEY": "${localEnv:DEVCONTAINER_OPENAI_API_KEY}",
-    "GEMINI_API_KEY": "${localEnv:DEVCONTAINER_GEMINI_API_KEY}",
-    "OPENROUTER_API_KEY": "${localEnv:DEVCONTAINER_OPENROUTER_API_KEY}",
-    "ZHIPU_API_KEY": "${localEnv:DEVCONTAINER_ZAI_API_KEY}"
+    "GITHUB_TOKEN": "${localEnv:RULESYNC_DEVCONTAINER_GITHUB_TOKEN}",
+    "OPENAI_API_KEY": "${localEnv:RULESYNC_DEVCONTAINER_OPENAI_API_KEY}",
+    "GEMINI_API_KEY": "${localEnv:RULESYNC_DEVCONTAINER_GEMINI_API_KEY}",
+    "OPENROUTER_API_KEY": "${localEnv:RULESYNC_DEVCONTAINER_OPENROUTER_API_KEY}",
+    "ZHIPU_API_KEY": "${localEnv:RULESYNC_DEVCONTAINER_ZAI_API_KEY}",
+    "OPENCODE_API_KEY": "${localEnv:RULESYNC_DEVCONTAINER_OPENCODE_API_KEY}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+. ~/.bashrc
+
 # Ensure node_modules and pnpm-store volumes have correct ownership for non-root user
 sudo chown -R node:node /workspace/node_modules 2>/dev/null || true
-sudo chown -R node:node /workspace/.pnpm-store 2>/dev/null || true
+sudo chown -R node:node /home/node/.pnpm-store 2>/dev/null || true
+
+# Ensure workspace-worktrees volume has correct ownership for non-root user to use gtr
+sudo mkdir -p /workspace-worktrees
+sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
+
+# Configure pnpm store directory for devcontainer
+pnpm config set store-dir /home/node/.pnpm-store
 
 # Install project dependencies
-pnpm i
+mise exec -c "pnpm i"
 
 gh auth setup-git

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,22 +1,31 @@
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "workspace"
 
-# list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   powershell          python              python_jedi         r                   rego
-#   ruby                ruby_solargraph     rust                scala               swift
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
 #   terraform           toml                typescript          typescript_vts      vue
 #   yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -34,8 +43,9 @@ encoding: "utf-8"
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore in all projects
-# same syntax as gitignore, so you can use * and **
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -43,52 +53,19 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions,
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -99,11 +76,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -131,3 +111,58 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,19 +1,7 @@
 [tools]
-bun = "1.3.6"
-deno = "2.6.5"
-gitleaks = "8.30.0"
-go = "1.25.4"
-lefthook = "2.1.4"
-node = "24.11.1"
-pnpm = "10.28.1"
-python = "3"
-rust = "latest"
+bun = "latest"
+go = "latest"
+node = "latest"
+pnpm = "latest"
+python = "latest"
 uv = "latest"
-
-[tasks.setup]
-description = "Install tools, tidy Go modules, and install git hooks"
-run = """
-mise install
-go mod tidy
-lefthook install
-"""


### PR DESCRIPTION
## Summary

Update development environment and tooling configuration.

- Bump devcontainer base image to `node:26` and use the flatt.tech npm registry
- Install `git-gtr` (git-worktree-runner) in the devcontainer
- Add `workspace-worktrees` and `opencode` volumes; move the pnpm store to the home directory
- Rename devcontainer env vars to the `RULESYNC_` prefix and add `OPENCODE_API_KEY`
- Simplify `mise.toml` to track `latest` versions
- Refresh `.serena/project.yml` to the latest Serena schema

## Test plan

- Config-only changes (devcontainer / mise / Serena). No application code affected.
- Verified no secrets are committed: the pre-commit `gitleaks` scan passed (no leaks found).