### PR TITLE
test: expand and harden E2E suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,8 @@ jobs:
           test -f dist/index.cjs
           test -f dist/index.d.ts
           test -f dist/index.d.cts
+
+      - name: Run E2E tests against built artifact
+        run: pnpm run test:e2e
+        env:
+          GHACTIVITIES_CMD: dist/index.js

--- a/.rulesync/rules/testing-guidelines.md
+++ b/.rulesync/rules/testing-guidelines.md
@@ -2,84 +2,23 @@
 root: false
 targets: ["*"]
 description: "When you write tests, must follow these guidelines."
-globs: ["**/*.test.ts"]
+globs: ["**/*.test.ts", "src/e2e/**/*.spec.ts"]
 ---
 
 # Testing Guidelines
 
-- Test code files should be placed next to the implementation. This is called the co-location pattern.
-  - For example, if the implementation file is `src/a.ts`, the test code file should be `src/a.test.ts`.
-- For all test code, to avoid polluting the git managed files, must use the unified pattern of targeting ./tmp/tests/projects/{RANDOM_STRING} as the project directory or ./tmp/tests/home/{RANDOM_STRING} as the pseudo-home directory.
-  - To use the unified test directory, you should use the `setupTestDirectory` function from `src/test-utils/test-directories.ts` and mock `process.cwd()` to return the test directory. You must not use `process.chdir()` instead of mocking `process.cwd()` because `process.chdir()` changes the current working directory globally and affects other tests. If you want to test some behavior in global mode, use the pseudo-home directory by `setupTestDirectory({ home: true })` and mock `getHomeDirectory()` to return the pseudo-home directory.
+## Unit tests
 
-    ```typescript
-    // Example with project directory
-    describe("Test Name", () => {
-      let testDir: string;
-      let cleanup: () => Promise<void>;
+- Unit test files use the `*.test.ts` suffix and are placed next to the implementation (the co-location pattern). For example, the test for `src/cli/parse-args.ts` is `src/cli/parse-args.test.ts`.
+- Run unit tests with `pnpm run test` (Vitest). They must not access the network or write to the filesystem outside a temporary directory.
 
-      beforeEach(async () => {
-        ({ testDir, cleanup } = await setupTestDirectory());
-        vi.spyOn(process, "cwd").mockReturnValue(testDir);
-      });
+## E2E tests
 
-      afterEach(async () => {
-        await cleanup();
-      });
-
-      it("Test Case", async () => {
-        // Run test using testDir
-        await RulesyncRule.fromFile({
-          baseDir: testDir,
-          relativeFilePath: "test.md",
-        });
-        // ...
-      });
-    });
-    ```
-
-    ```typescript
-    // Example with pseudo-home directory
-    const { getHomeDirectoryMock } = vi.hoisted(() => {
-      return {
-        getHomeDirectoryMock: vi.fn(),
-      };
-    });
-    vi.mock("../utils/file.js", async () => {
-      const actual = await vi.importActual<typeof import("../utils/file.js")>("../utils/file.js");
-      return {
-        ...actual,
-        getHomeDirectory: getHomeDirectoryMock,
-      };
-    });
-
-    describe("Test Name", () => {
-      let testDir: string;
-      let cleanup: () => Promise<void>;
-
-      beforeEach(async () => {
-        ({ testDir, cleanup } = await setupTestDirectory({ home: true }));
-        getHomeDirectoryMock.mockReturnValue(testDir);
-      });
-
-      afterEach(async () => {
-        await cleanup();
-        getHomeDirectoryMock.mockClear();
-      });
-
-      it("Test Case", async () => {
-        // Run test using testDir
-        const subDir = join(testDir, "subdir");
-        await ensureDir(subDir);
-        // ...
-      });
-    });
-    ```
-
-  - Exceptionally, in E2E testing, you can use process.chdir() to change the current working directory to the test directory because E2E tests are intended to simulate conditions that are as close as possible to real user operations.
-
-- In test, don't change dirs or files out of the project directory even though it's in global mode to make it easier to test some behavior and avoid polluting those.
-- When `NODE_ENV` is `test`:
-  - All logs by `Logger` in `src/utils/logger.ts` are suppressed.
-    - When you want to log in test, use `console.log` and run `npx vitest run --silent=false` to see the logs.
-  - `getHomeDirectory()` in `src/utils/file.ts` throws an error to enforce explicit mocking.
+- E2E test files use the `*.spec.ts` suffix and live under `src/e2e/`. Run them with `pnpm run test:e2e`, which uses the separate `vitest.e2e.config.ts` config.
+- E2E tests invoke the real CLI through the helpers in `src/e2e/e2e-helper.ts`:
+  - `runCli(args)` executes the CLI and resolves with `{ stdout, stderr }`; on a non-zero exit it rejects with an error carrying the same `stdout`/`stderr` fields.
+  - `useTestDirectory()` creates an isolated temp directory and `process.chdir()`s into it for each test, then restores and removes it afterwards.
+- By default the E2E suite runs the TypeScript source via `tsx`. Set the `GHACTIVITIES_CMD` environment variable (e.g. `GHACTIVITIES_CMD=dist/index.js`) to run the same specs against the built bundle in `dist/`. CI runs the suite both ways so the shipped artifact is exercised end-to-end.
+- Because `useTestDirectory()` relies on `process.chdir()` (a process-global operation), E2E tests must run serially. This is enforced by `maxWorkers: 1` and `fileParallelism: false` in `vitest.e2e.config.ts` — do not remove them.
+- The CLI reports argument-validation errors through `@clack/prompts`, which writes to **stdout** (not stderr) and exits non-zero. Assert against the rejected error's `stdout`, not `stderr`.
+- E2E tests must not depend on network access or a real `GITHUB_TOKEN`. Cover only behavior that resolves before any GitHub API call is made, such as `--version`, `--help`, and argument validation.

--- a/src/e2e/e2e-cli-args.spec.ts
+++ b/src/e2e/e2e-cli-args.spec.ts
@@ -26,6 +26,18 @@ describe("E2E: CLI option validation", () => {
     });
   });
 
+  it("rejects a malformed --since date", async () => {
+    await expect(runCli(["--since", "not-a-date"])).rejects.toMatchObject({
+      stdout: expect.stringMatching(/since/i),
+    });
+  });
+
+  it("rejects a malformed --until date", async () => {
+    await expect(runCli(["--until", "not-a-date"])).rejects.toMatchObject({
+      stdout: expect.stringMatching(/until/i),
+    });
+  });
+
   it("rejects an unknown option", async () => {
     await expect(runCli(["--nope"])).rejects.toMatchObject({
       stdout: expect.stringMatching(/unknown option/i),

--- a/src/e2e/e2e-helper.ts
+++ b/src/e2e/e2e-helper.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach } from "vitest";
 
@@ -11,12 +11,29 @@ const originalCwd = process.cwd();
 const tsxPath = join(originalCwd, "node_modules", ".bin", "tsx");
 const cliPath = join(originalCwd, "src", "cli", "index.ts");
 
-// If GHACTIVITIES_CMD points at a built binary, run it; otherwise run the
-// source directly via tsx.
-const ghCmd = process.env.GHACTIVITIES_CMD
-  ? join(originalCwd, process.env.GHACTIVITIES_CMD)
-  : tsxPath;
-const ghArgs = process.env.GHACTIVITIES_CMD ? [] : [cliPath];
+// By default the E2E suite runs the TypeScript source through tsx. When
+// GHACTIVITIES_CMD is set (CI runs the suite a second time this way), the same
+// specs run against the built bundle in dist/. Validate the path so a typo
+// fails loudly instead of silently testing the wrong thing, and run the bundle
+// via the current Node binary for portability rather than relying on the
+// executable bit / shebang.
+function resolveRunner(): { cmd: string; baseArgs: string[] } {
+  const raw = process.env.GHACTIVITIES_CMD;
+  if (!raw) {
+    return { cmd: tsxPath, baseArgs: [cliPath] };
+  }
+  const resolved = resolve(originalCwd, raw);
+  const parts = resolved.split(sep);
+  const valid = parts.at(-2) === "dist" && /^index\.(?:js|cjs)$/.test(parts.at(-1) ?? "");
+  if (!valid) {
+    throw new Error(
+      `Invalid GHACTIVITIES_CMD: must point at 'dist/index.js' or 'dist/index.cjs': ${raw}`,
+    );
+  }
+  return { cmd: process.execPath, baseArgs: [resolved] };
+}
+
+const { cmd: ghCmd, baseArgs: ghArgs } = resolveRunner();
 
 /** Run the ghactivities CLI with args, returning { stdout, stderr }. */
 export function runCli(args: string[], opts: { cwd?: string } = {}) {


### PR DESCRIPTION
## Summary

Expand and harden the E2E test suite, referencing the setup in `dyoshikawa/rulesync`.

- **Helper (`src/e2e/e2e-helper.ts`)**: validate `GHACTIVITIES_CMD` (must point at `dist/index.js`/`dist/index.cjs`) so a typo fails loudly, and run the built bundle via the current Node binary for portability. The same specs now cover both the `tsx` source and the shipped `dist/` artifact.
- **Coverage**: add invalid `--since` / `--until` date E2E cases (previously only `--order` / `--visibility` / `--max-length-size` / unknown-option were covered).
- **CI**: run the E2E suite a second time against `dist/index.js` (`GHACTIVITIES_CMD=dist/index.js`) after build, so the published artifact is exercised end-to-end — mirroring rulesync's binary E2E.
- **`testing-guidelines` rule**: replace stale rulesync-specific references (`setupTestDirectory`, `RulesyncRule`, `getHomeDirectory`, home/global mode) with ghactivities' actual unit/E2E conventions.

## Test plan

- `pnpm run test:e2e` (source via tsx): 8 passed
- `GHACTIVITIES_CMD=dist/index.js pnpm run test:e2e` (built bundle): 8 passed
- `pnpm cicheck`: all green (fmt / oxlint / tsgo / 30 unit tests / cspell / secretlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)