### PR TITLE
fix(github): rename reserved GraphQL variable $query to $searchQuery

### DIFF
--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -7,8 +7,8 @@ export const VIEWER_QUERY = `
 `;
 
 export const ISSUE_SEARCH_QUERY = `
-  query ($query: String!, $first: Int!, $after: String) {
-    search(type: ISSUE, query: $query, first: $first, after: $after) {
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor
@@ -31,8 +31,8 @@ export const ISSUE_SEARCH_QUERY = `
 `;
 
 export const ISSUE_COMMENT_SEARCH_QUERY = `
-  query ($query: String!, $first: Int!, $after: String) {
-    search(type: ISSUE, query: $query, first: $first, after: $after) {
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor
@@ -66,8 +66,8 @@ export const ISSUE_COMMENT_SEARCH_QUERY = `
 `;
 
 export const DISCUSSION_SEARCH_QUERY = `
-  query ($query: String!, $first: Int!, $after: String) {
-    search(type: DISCUSSION, query: $query, first: $first, after: $after) {
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: DISCUSSION, query: $searchQuery, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor
@@ -90,8 +90,8 @@ export const DISCUSSION_SEARCH_QUERY = `
 `;
 
 export const DISCUSSION_COMMENT_SEARCH_QUERY = `
-  query ($query: String!, $first: Int!, $after: String) {
-    search(type: DISCUSSION, query: $query, first: $first, after: $after) {
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: DISCUSSION, query: $searchQuery, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor
@@ -125,8 +125,8 @@ export const DISCUSSION_COMMENT_SEARCH_QUERY = `
 `;
 
 export const PULL_REQUEST_SEARCH_QUERY = `
-  query ($query: String!, $first: Int!, $after: String) {
-    search(type: ISSUE, query: $query, first: $first, after: $after) {
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor
@@ -149,8 +149,8 @@ export const PULL_REQUEST_SEARCH_QUERY = `
 `;
 
 export const PULL_REQUEST_COMMENT_SEARCH_QUERY = `
-  query ($query: String!, $first: Int!, $after: String) {
-    search(type: ISSUE, query: $query, first: $first, after: $after) {
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
       pageInfo {
         hasNextPage
         endCursor

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { GitHubService } from "./github.js";
+
+// Records every call the GitHubService makes to @octokit/graphql so the test
+// can assert none of them uses a reserved variable key. Declared via
+// vi.hoisted so it is available inside the (hoisted) vi.mock factory below.
+const { calls } = vi.hoisted(() => ({
+  calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
+}));
+
+// Mock @octokit/graphql with a stub that returns empty-but-valid shapes for
+// each query the service issues, and records the (query, variables) pairs.
+vi.mock("@octokit/graphql", () => {
+  const impl = (query: string, variables: Record<string, unknown> = {}) => {
+    calls.push({ query, variables });
+
+    if (query.includes("contributionsCollection")) {
+      return Promise.resolve({
+        user: { contributionsCollection: { commitContributionsByRepository: [] } },
+      });
+    }
+    if (query.includes("defaultBranchRef")) {
+      return Promise.resolve({ repository: { defaultBranchRef: null } });
+    }
+    if (query.includes("search(type:")) {
+      return Promise.resolve({
+        search: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+      });
+    }
+    // The only remaining queries are the two viewer lookups; the id variant is
+    // the one that also selects the `id` field.
+    if (query.includes("id")) {
+      return Promise.resolve({ viewer: { id: "VIEWER_ID", login: "testuser" } });
+    }
+    return Promise.resolve({ viewer: { login: "testuser" } });
+  };
+
+  return { graphql: Object.assign(impl, { defaults: () => impl }) };
+});
+
+describe("GitHubService GraphQL variables", () => {
+  it("never passes the reserved 'query' key to @octokit/graphql", async () => {
+    calls.length = 0;
+
+    const service = new GitHubService({
+      token: "test-token",
+      since: new Date("2024-01-01T00:00:00Z"),
+      until: new Date("2024-01-15T00:00:00Z"),
+      visibility: "public",
+    });
+
+    const events = await service.fetchAllEvents();
+    expect(events).toEqual([]);
+
+    // The service must actually have issued queries (otherwise the assertion
+    // below would pass vacuously).
+    expect(calls.length).toBeGreaterThan(0);
+
+    for (const call of calls) {
+      expect(
+        Object.hasOwn(call.variables, "query"),
+        `@octokit/graphql reserves "query"; variables for the following query must not use it:\n${call.query}`,
+      ).toBe(false);
+    }
+
+    // The search queries must supply their search string under the renamed
+    // variable instead.
+    const searchCalls = calls.filter((call) => call.query.includes("search(type:"));
+    expect(searchCalls.length).toBeGreaterThan(0);
+    for (const call of searchCalls) {
+      expect(Object.hasOwn(call.variables, "searchQuery")).toBe(true);
+    }
+  });
+});

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -99,7 +99,7 @@ export class GitHubService {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
 
-    const query = this.buildSearchQuery({
+    const searchQuery = this.buildSearchQuery({
       user: username,
       qualifiers: `author:${username} is:issue`,
     });
@@ -108,7 +108,7 @@ export class GitHubService {
     while (true) {
       const response: IssueSearchResponse = await this.graphqlWithAuth<IssueSearchResponse>(
         ISSUE_SEARCH_QUERY,
-        { query, first: 100, after: cursor },
+        { searchQuery, first: 100, after: cursor },
       );
 
       for (const node of response.search.nodes) {
@@ -139,7 +139,7 @@ export class GitHubService {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
 
-    const query = this.buildSearchQuery({
+    const searchQuery = this.buildSearchQuery({
       user: username,
       qualifiers: `commenter:${username} is:issue`,
     });
@@ -148,7 +148,7 @@ export class GitHubService {
     while (true) {
       const response: IssueCommentSearchResponse =
         await this.graphqlWithAuth<IssueCommentSearchResponse>(ISSUE_COMMENT_SEARCH_QUERY, {
-          query,
+          searchQuery,
           first: 100,
           after: cursor,
         });
@@ -186,7 +186,7 @@ export class GitHubService {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
 
-    const query = this.buildSearchQuery({
+    const searchQuery = this.buildSearchQuery({
       user: username,
       qualifiers: `author:${username} type:discussion`,
     });
@@ -195,7 +195,7 @@ export class GitHubService {
     while (true) {
       const response: DiscussionSearchResponse =
         await this.graphqlWithAuth<DiscussionSearchResponse>(DISCUSSION_SEARCH_QUERY, {
-          query,
+          searchQuery,
           first: 100,
           after: cursor,
         });
@@ -228,7 +228,7 @@ export class GitHubService {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
 
-    const query = this.buildSearchQuery({
+    const searchQuery = this.buildSearchQuery({
       user: username,
       qualifiers: `commenter:${username} type:discussion`,
     });
@@ -238,7 +238,7 @@ export class GitHubService {
       const response: DiscussionCommentSearchResponse =
         await this.graphqlWithAuth<DiscussionCommentSearchResponse>(
           DISCUSSION_COMMENT_SEARCH_QUERY,
-          { query, first: 100, after: cursor },
+          { searchQuery, first: 100, after: cursor },
         );
 
       for (const node of response.search.nodes) {
@@ -274,7 +274,7 @@ export class GitHubService {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
 
-    const query = this.buildSearchQuery({
+    const searchQuery = this.buildSearchQuery({
       user: username,
       qualifiers: `author:${username} is:pr`,
     });
@@ -283,7 +283,7 @@ export class GitHubService {
     while (true) {
       const response: PullRequestSearchResponse =
         await this.graphqlWithAuth<PullRequestSearchResponse>(PULL_REQUEST_SEARCH_QUERY, {
-          query,
+          searchQuery,
           first: 100,
           after: cursor,
         });
@@ -316,7 +316,7 @@ export class GitHubService {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
 
-    const query = this.buildSearchQuery({
+    const searchQuery = this.buildSearchQuery({
       user: username,
       qualifiers: `commenter:${username} is:pr`,
     });
@@ -326,7 +326,7 @@ export class GitHubService {
       const response: PullRequestCommentSearchResponse =
         await this.graphqlWithAuth<PullRequestCommentSearchResponse>(
           PULL_REQUEST_COMMENT_SEARCH_QUERY,
-          { query, first: 100, after: cursor },
+          { searchQuery, first: 100, after: cursor },
         );
 
       for (const node of response.search.nodes) {


### PR DESCRIPTION
## Summary

Fix a runtime bug that broke all search-based activity fetching, found by actually running the CLI against a real token.

`@octokit/graphql` reserves `query` as a key in the **variables** object (the first positional arg is the query document itself). The search queries declared a GraphQL variable literally named `$query` and `github.ts` passed `{ query, ... }`, so every search call threw:

```
[@octokit/graphql] "query" cannot be used as variable name
```

This broke fetching of **issues, issue comments, discussions, discussion comments, pull requests, and pull request comments**. Only commit fetching worked (it uses different variable names), so the tool was effectively non-functional on `main`.

## Changes

- Rename the search variable and the passed key `$query` → `$searchQuery` across the six search queries (`github-queries.ts`) and their call sites (`github.ts`).
- Add a regression test (`github.test.ts`) that mocks `@octokit/graphql`, drives `fetchAllEvents()`, and asserts the service never passes a reserved `query` key (and that search calls use `searchQuery`). Without a real token CI can't hit the API, so this guards the wiring that `cicheck` previously left uncovered.

## Test plan

- `pnpm cicheck`: all green (fmt / oxlint / tsgo / 31 unit tests / cspell / secretlint)
- Manual run against a real `GITHUB_TOKEN` now succeeds: **354 public events** collected (PR 94, Commit 103, PRComment 71, Issue 63, IssueComment 23) over the default 2-week window

🤖 Generated with [Claude Code](https://claude.com/claude-code)