### PR TITLE
feat: add --max-tokens option to split output by token count

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ To include private repositories (`--visibility private` or `--visibility all`), 
 
 ## Options
 
-| Option              | Description                                                                                           | Default                                  |
-| ------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `--github-token`    | GitHub access token.                                                                                  | `GITHUB_TOKEN` env, then `gh auth token` |
-| `--output`          | Output file path.                                                                                     | `./ghactivities.json`                    |
-| `--since`           | Start of the range, in ISO 8601 format.                                                               | 2 weeks ago                              |
-| `--until`           | End of the range, in ISO 8601 format.                                                                 | now                                      |
-| `--visibility`      | Repository visibility: `public`, `private`, or `all`.                                                 | `public`                                 |
-| `--max-length-size` | Maximum output file size (e.g. `1B`, `2K`, `2M`, `1G`). Larger output is split across multiple files. | `1M`                                     |
-| `--order`           | Event order by date: `asc` or `desc`.                                                                 | `asc`                                    |
-| `--help`            | Show the help message.                                                                                |                                          |
-| `--version`         | Show the version number.                                                                              |                                          |
+| Option              | Description                                                                                                                                                                                | Default                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| `--github-token`    | GitHub access token.                                                                                                                                                                       | `GITHUB_TOKEN` env, then `gh auth token` |
+| `--output`          | Output file path.                                                                                                                                                                          | `./ghactivities.json`                    |
+| `--since`           | Start of the range, in ISO 8601 format.                                                                                                                                                    | 2 weeks ago                              |
+| `--until`           | End of the range, in ISO 8601 format.                                                                                                                                                      | now                                      |
+| `--visibility`      | Repository visibility: `public`, `private`, or `all`.                                                                                                                                      | `public`                                 |
+| `--max-length-size` | Maximum output file size (e.g. `1B`, `2K`, `2M`, `1G`). Larger output is split across multiple files.                                                                                      | `1M`                                     |
+| `--max-tokens`      | Maximum number of tokens per output file (counted with `js-tiktoken`'s `cl100k_base` encoding). Output is split when a file would exceed this. Applied in addition to `--max-length-size`. | (disabled)                               |
+| `--order`           | Event order by date: `asc` or `desc`.                                                                                                                                                      | `asc`                                    |
+| `--help`            | Show the help message.                                                                                                                                                                     |                                          |
+| `--version`         | Show the version number.                                                                                                                                                                   |                                          |
 
 ## Output
 
@@ -78,7 +79,9 @@ Each event shares a common shape and adds type-specific fields:
 
 ### File splitting
 
-When the JSON output would exceed `--max-length-size`, it is split into multiple files named after `--output` with a numeric suffix, for example `./ghactivities_1.json`, `./ghactivities_2.json`, and so on. A single event that is larger than the limit is still written to its own file.
+When the JSON output would exceed `--max-length-size` (or `--max-tokens`, if set), it is split into multiple files named after `--output` with a numeric suffix, for example `./ghactivities_1.json`, `./ghactivities_2.json`, and so on. A single event that is larger than the limit is still written to its own file.
+
+When both `--max-length-size` and `--max-tokens` are given, a file is split as soon as it would exceed **either** limit. Token counts are computed with [`js-tiktoken`](https://www.npmjs.com/package/js-tiktoken) using the `cl100k_base` encoding.
 
 ## Examples
 

--- a/cspell.json
+++ b/cspell.json
@@ -207,6 +207,7 @@
     "npmrc",
     "esbuild",
     "npmjs",
-    "tldjs"
+    "tldjs",
+    "tiktoken"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"@clack/prompts": "1.0.0",
 		"@octokit/graphql": "9.0.3",
 		"@octokit/rest": "22.0.1",
+		"js-tiktoken": "^1.0.21",
 		"zod": "4.3.6"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@octokit/rest':
         specifier: 22.0.1
         version: 22.0.1
+      js-tiktoken:
+        specifier: ^1.0.21
+        version: 1.0.21
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -1622,6 +1625,9 @@ packages:
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -2302,6 +2308,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -4465,6 +4474,8 @@ snapshots:
       - debug
       - supports-color
 
+  base64-js@1.5.1: {}
+
   before-after-hook@4.0.0: {}
 
   binaryextensions@6.11.0:
@@ -5223,6 +5234,10 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
+
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
 
   js-tokens@10.0.0: {}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ async function main(): Promise<void> {
       events: sorted,
       output: options.output,
       maxLengthSize: options.maxLengthSize,
+      maxTokens: options.maxTokens,
     });
     s.stop(`Written to ${files.join(", ")}`);
 

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -17,6 +17,8 @@ describe("parseCliArgs", () => {
       "all",
       "--max-length-size",
       "2M",
+      "--max-tokens",
+      "1000",
       "--order",
       "desc",
     ]);
@@ -26,6 +28,7 @@ describe("parseCliArgs", () => {
     expect(result.until.toISOString()).toBe("2024-06-01T00:00:00.000Z");
     expect(result.visibility).toBe("all");
     expect(result.maxLengthSize).toBe(2 * 1024 * 1024);
+    expect(result.maxTokens).toBe(1000);
     expect(result.order).toBe("desc");
   });
 
@@ -34,6 +37,7 @@ describe("parseCliArgs", () => {
     expect(result.output).toBe("./ghactivities.json");
     expect(result.visibility).toBe("public");
     expect(result.maxLengthSize).toBe(1024 * 1024);
+    expect(result.maxTokens).toBeUndefined();
     expect(result.order).toBe("asc");
     expect(result.since).toBeInstanceOf(Date);
     expect(result.until).toBeInstanceOf(Date);
@@ -53,6 +57,12 @@ describe("parseCliArgs", () => {
 
   it("throws on invalid max-length-size", () => {
     expect(() => parseCliArgs(["--max-length-size", "abc"])).toThrow();
+  });
+
+  it("throws on invalid max-tokens", () => {
+    expect(() => parseCliArgs(["--max-tokens", "abc"])).toThrow();
+    expect(() => parseCliArgs(["--max-tokens", "0"])).toThrow();
+    expect(() => parseCliArgs(["--max-tokens", "-5"])).toThrow();
   });
 
   it("calls process.exit on --help", () => {

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -36,6 +36,13 @@ const ArgsSchema = z.object({
       },
     ),
   ),
+  maxTokens: z.optional(
+    z.string().check(
+      z.refine((v) => /^\d+$/.test(v.trim()) && Number(v.trim()) > 0, {
+        message: "Invalid value for --max-tokens. Expected a positive integer (e.g., 1000).",
+      }),
+    ),
+  ),
   order: z.enum(["asc", "desc"]),
 });
 
@@ -55,6 +62,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
       until: { type: "string", default: new Date().toISOString() },
       visibility: { type: "string", default: "public" },
       "max-length-size": { type: "string", default: "1M" },
+      "max-tokens": { type: "string" },
       order: { type: "string", default: "asc" },
       help: { type: "boolean", default: false },
       version: { type: "boolean", default: false },
@@ -79,6 +87,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     until: values.until,
     visibility: values.visibility,
     maxLengthSize: values["max-length-size"],
+    maxTokens: values["max-tokens"],
     order: values.order,
   });
 
@@ -89,6 +98,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     until: new Date(parsed.until),
     visibility: parsed.visibility as Visibility,
     maxLengthSize: parseSize(parsed.maxLengthSize),
+    maxTokens: parsed.maxTokens === undefined ? undefined : Number(parsed.maxTokens.trim()),
     order: parsed.order as Order,
   };
 }
@@ -104,6 +114,7 @@ Options:
   --until             End date in ISO8601 format (default: now)
   --visibility        Repository visibility: public, private, all (default: public)
   --max-length-size   Max output file size: e.g., 1B, 2K, 2M (default: 1M)
+  --max-tokens        Max tokens per output file (js-tiktoken, cl100k_base); splits when exceeded
   --order             Event order: asc, desc (default: asc)
   --help              Show this help message
   --version           Show the version number

--- a/src/e2e/e2e-cli-args.spec.ts
+++ b/src/e2e/e2e-cli-args.spec.ts
@@ -26,6 +26,12 @@ describe("E2E: CLI option validation", () => {
     });
   });
 
+  it("rejects a malformed --max-tokens value", async () => {
+    await expect(runCli(["--max-tokens", "abc"])).rejects.toMatchObject({
+      stdout: expect.stringMatching(/max-tokens|token/i),
+    });
+  });
+
   it("rejects a malformed --since date", async () => {
     await expect(runCli(["--since", "not-a-date"])).rejects.toMatchObject({
       stdout: expect.stringMatching(/since/i),

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -8,5 +8,6 @@ export interface CliOptions {
   until: Date;
   visibility: Visibility;
   maxLengthSize: number;
+  maxTokens?: number | undefined;
   order: Order;
 }

--- a/src/utils/count-tokens.test.ts
+++ b/src/utils/count-tokens.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { countTokens } from "./count-tokens.js";
+
+describe("countTokens", () => {
+  it("returns 0 for an empty string", () => {
+    expect(countTokens("")).toBe(0);
+  });
+
+  it("counts tokens for a simple string", () => {
+    expect(countTokens("hello world")).toBeGreaterThan(0);
+  });
+
+  it("counts more tokens for longer text", () => {
+    const short = countTokens("hello");
+    const long = countTokens("hello world this is a longer sentence with more tokens");
+    expect(long).toBeGreaterThan(short);
+  });
+});

--- a/src/utils/count-tokens.ts
+++ b/src/utils/count-tokens.ts
@@ -1,0 +1,8 @@
+import { getEncoding, type Tiktoken } from "js-tiktoken";
+
+let encoder: Tiktoken | undefined;
+
+export function countTokens(text: string): number {
+  encoder ??= getEncoding("cl100k_base");
+  return encoder.encode(text).length;
+}

--- a/src/utils/file-writer.test.ts
+++ b/src/utils/file-writer.test.ts
@@ -62,6 +62,38 @@ describe("writeEventsToFiles", () => {
     expect(files[0]).toContain("events_1.json");
   });
 
+  it("splits into multiple files when exceeding token limit", async () => {
+    const events = [makeEvent(1), makeEvent(2), makeEvent(3)];
+    const output = join(tempDir, "events.json");
+
+    const files = await writeEventsToFiles({
+      events,
+      output,
+      maxLengthSize: 1024 * 1024,
+      maxTokens: 30,
+    });
+
+    expect(files.length).toBeGreaterThan(1);
+    for (const file of files) {
+      const content = await readFile(file, "utf-8");
+      const parsed = JSON.parse(content) as GitHubEvent[];
+      expect(Array.isArray(parsed)).toBe(true);
+    }
+    expect(files[0]).toContain("events_1.json");
+  });
+
+  it("writes a single file when within both size and token limits", async () => {
+    const events = [makeEvent(1)];
+    const output = join(tempDir, "events.json");
+    const files = await writeEventsToFiles({
+      events,
+      output,
+      maxLengthSize: 1024 * 1024,
+      maxTokens: 1_000_000,
+    });
+    expect(files).toEqual([output]);
+  });
+
   it("handles empty events array", async () => {
     const output = join(tempDir, "events.json");
     const files = await writeEventsToFiles({

--- a/src/utils/file-writer.ts
+++ b/src/utils/file-writer.ts
@@ -3,28 +3,47 @@ import { basename, dirname, extname, join } from "node:path";
 
 import type { GitHubEvent } from "../types/events.js";
 
+import { countTokens } from "./count-tokens.js";
+
+function exceedsLimit(params: {
+  json: string;
+  maxLengthSize: number;
+  maxTokens?: number | undefined;
+}): boolean {
+  const { json, maxLengthSize, maxTokens } = params;
+  if (Buffer.byteLength(json, "utf-8") > maxLengthSize) {
+    return true;
+  }
+  if (maxTokens !== undefined && countTokens(json) > maxTokens) {
+    return true;
+  }
+  return false;
+}
+
 export async function writeEventsToFiles(params: {
   events: GitHubEvent[];
   output: string;
   maxLengthSize: number;
+  maxTokens?: number | undefined;
 }): Promise<string[]> {
-  const { events, output, maxLengthSize } = params;
+  const { events, output, maxLengthSize, maxTokens } = params;
   const json = JSON.stringify(events, null, 2);
 
-  if (Buffer.byteLength(json, "utf-8") <= maxLengthSize) {
+  if (!exceedsLimit({ json, maxLengthSize, maxTokens })) {
     await writeFile(output, json, "utf-8");
     return [output];
   }
 
-  return splitAndWriteFiles({ events, output, maxLengthSize });
+  return splitAndWriteFiles({ events, output, maxLengthSize, maxTokens });
 }
 
 async function splitAndWriteFiles(params: {
   events: GitHubEvent[];
   output: string;
   maxLengthSize: number;
+  maxTokens?: number | undefined;
 }): Promise<string[]> {
-  const { events, output, maxLengthSize } = params;
+  const { events, output, maxLengthSize, maxTokens } = params;
   const dir = dirname(output);
   const ext = extname(output);
   const base = basename(output, ext);
@@ -37,7 +56,7 @@ async function splitAndWriteFiles(params: {
     currentChunk.push(event);
     const chunkJson = JSON.stringify(currentChunk, null, 2);
 
-    if (Buffer.byteLength(chunkJson, "utf-8") > maxLengthSize) {
+    if (exceedsLimit({ json: chunkJson, maxLengthSize, maxTokens })) {
       if (currentChunk.length === 1) {
         const filePath = join(dir, `${base}_${String(fileIndex)}${ext}`);
         await writeFile(filePath, chunkJson, "utf-8");


### PR DESCRIPTION
## Summary

Adds a new `--max-tokens` option that splits the output into multiple files based on **token count**, in addition to the existing byte-size limit (`--max-length-size`).

- Token counting uses [`js-tiktoken`](https://www.npmjs.com/package/js-tiktoken) with the `cl100k_base` encoding (new `src/utils/count-tokens.ts`, with a module-level cached encoder).
- `file-writer.ts` now flushes a chunk when it exceeds **either** the byte-size limit **or** the token limit. When `--max-tokens` is omitted, behavior is unchanged (size-only).
- CLI: new `--max-tokens` option (positive integer, validated with `zod/mini`), wired through `CliOptions`, parse-args, help text, and `index.ts`.

## Test plan

- Unit tests: `count-tokens.test.ts`, token-split cases in `file-writer.test.ts`, `--max-tokens` parse/validation in `parse-args.test.ts`.
- E2E: `--max-tokens` malformed-value validation in `e2e-cli-args.spec.ts`.
- `pnpm cicheck` (code + content) and `pnpm run test:e2e` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)