### PR TITLE
chore(oxlint): enforce complexity max of 20

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,7 @@
   },
 
   "rules": {
+    "complexity": ["error", { "max": 20 }],
     "eqeqeq": "error",
     "import/no-cycle": "error",
     "no-console": "off",


### PR DESCRIPTION
## Summary

- Add the `complexity` rule to `.oxlintrc.json` with a `max` of 20 to guard against overly complex functions.

## Details

The existing codebase already satisfies this threshold with plenty of margin (the highest function complexity is well below 10), so no refactoring was required. The rule is now enforced going forward via `pnpm run oxlint` (`--max-warnings 0`).

## Test plan

- [x] `pnpm cicheck` passes (format, oxlint, typecheck, tests, cspell, secretlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)