### PR TITLE
feat: LLM scan subcommand, --scan one-stop option, and /goal-pr command

### DIFF
--- a/.rulesync/commands/goal-pr.md
+++ b/.rulesync/commands/goal-pr.md
@@ -1,0 +1,127 @@
+---
+targets:
+  - "*"
+description: >-
+  Drive a pull request to a clean state and merge it: run /review-pr, fix every
+  mid-or-above finding, and repeat until no mid-or-above findings remain, then
+  merge. Use when the user wants to finish a PR by reviewing, fixing, and
+  merging it, or triggers on "/goal-pr".
+---
+
+# Goal PR Command
+
+target_pr = $ARGUMENTS
+
+This command drives a pull request all the way to merge. It repeatedly runs
+`/review-pr`, fixes every finding of severity `mid` or above, and merges the PR
+once a review round reports no `mid`-or-above findings.
+
+## 0. Determine and Prepare the Target PR
+
+1. If `target_pr` is provided (e.g. `123`, `#123`, or a PR URL), use it.
+2. Otherwise, look for the PR of the current branch:
+
+   ```bash
+   gh pr view --json number,title,state,headRefName 2>/dev/null
+   ```
+
+3. If no PR exists yet, create one (this satisfies the "PR is the goal" intent):
+   - Run the `/commit-push-pr` command to commit the current changes, push the
+     branch, and open a PR.
+   - Then resolve `target_pr` to the freshly created PR number.
+
+Confirm that the current local branch is the PR's head branch, because the fix
+phase below must commit and push fixes onto that branch. If they differ, ask the
+user how to proceed and stop.
+
+## 1. Exit Condition
+
+The loop exits when a single review round satisfies **both** of:
+
+- **0** findings of severity `mid`, `high`, or `critical` (only `low` findings,
+  or none at all, may remain).
+- The PR's GitHub Actions checks are **green** — no check is `fail` or
+  `pending`.
+
+Set a hard safety cap of **10 iterations**. If the exit condition is still not
+met at the cap, stop the loop and report the remaining findings (and any failing
+CI) to the user for a manual decision instead of merging.
+
+## 2. Iteration Loop
+
+Repeat the following until the exit condition is satisfied or the cap is hit.
+
+### 2-1. Review Phase
+
+Run the `/review-pr` command with `target_pr`. It assigns each finding a
+severity (`low` / `mid` / `high` / `critical`) and a sequential number, and also
+reports the GitHub Actions workflow status.
+
+Note: `/review-pr` only reads remote state and must not switch the local branch.
+Keep that constraint intact during the review phase.
+
+### 2-2. Evaluate the Exit Condition
+
+Use both the findings and the GitHub Actions status from the review result.
+
+- If `mid + high + critical == 0` **and** CI is green (no `fail` / `pending`
+  check): exit the loop and go to **Section 3**.
+- If there are `mid`-or-above findings, or any CI check is failing: proceed to
+  the fix phase to address them.
+- If the findings are clean but CI is still `pending`: wait for the checks to
+  finish (re-check with `gh pr checks <pr>`), then re-evaluate. Do not proceed to
+  merge while checks are pending.
+
+### 2-3. Fix Phase
+
+Fix every finding of severity `mid` or above on the current branch (you may also
+fix `low` findings opportunistically). Unlike the review phase, this phase works
+on the local branch directly:
+
+1. Edit the relevant files to address each `mid`-or-above finding. If you
+   intentionally reject a finding, record the reason and treat it as resolved.
+2. Run `pnpm cicheck` (or the narrower `pnpm cicheck:code` / `cicheck:content`
+   when appropriate) and fix any failures before continuing.
+3. Stage only the files you changed for the fix (review `git status` first so
+   unrelated or generated files are not swept in), commit with a descriptive
+   message, and push to the PR's head branch:
+
+   ```bash
+   git status
+   git add <changed files>
+   git commit -m "<message>"
+   git push origin HEAD
+   ```
+
+Emit a short status line such as
+`Iteration N — mid: X, high: Y, critical: Z; pushed fixes`, then return to
+**Section 2-1** so the updated PR (and its CI) is reviewed again.
+
+## 3. Merge
+
+Only reach this step once the exit condition in Section 1 holds — clean findings
+**and** green CI. Merge the PR by running the `/merge-pr` command with
+`target_pr`. That command verifies the PR is open, checks GitHub Actions status,
+merges with `gh pr merge --admin --merge`, and cleans up the local branch.
+
+Safety rules for the merge:
+
+- **Never merge while any check is `fail` or `pending`.** `gh pr merge --admin`
+  bypasses required checks, so it must not be used to force past red or
+  in-progress CI. If CI is failing, return to the fix phase; if it is pending,
+  wait.
+- If the PR touches GitHub Actions workflows, build/release configuration, or
+  dependency manifests (e.g. `package.json`, lockfiles), do **not** auto-merge.
+  Stop and ask the user to confirm, since these changes carry higher risk.
+
+## 4. Final Report
+
+After the loop ends, report to the user:
+
+- **Outcome**: `Merged` (exit condition met and PR merged) or `Capped` (hit the
+  iteration cap without converging; not merged).
+- **Iterations**: how many review/fix rounds were executed.
+- **Final severity summary**: the counts per severity from the last review
+  round.
+- **Result**: the merged PR number and title, or — when capped — the list of
+  remaining `mid`-or-above findings for the user to decide on.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ To include private repositories (`--visibility private` or `--visibility all`), 
 | `--max-length-size` | Maximum output file size (e.g. `1B`, `2K`, `2M`, `1G`). Larger output is split across multiple files.                                                                                      | `1M`                                     |
 | `--max-tokens`      | Maximum number of tokens per output file (counted with `js-tiktoken`'s `cl100k_base` encoding). Output is split when a file would exceed this. Applied in addition to `--max-length-size`. | (disabled)                               |
 | `--order`           | Event order by date: `asc` or `desc`.                                                                                                                                                      | `asc`                                    |
+| `--scan`            | After collecting, scan the output with an LLM and emit a Markdown report (see [Scanning activity with an LLM](#scanning-activity-with-an-llm) for the provider options).                   | off                                      |
+| `--scan-output`     | With `--scan`, write the report to this file instead of stdout.                                                                                                                            | stdout                                   |
 | `--help`            | Show the help message.                                                                                                                                                                     |                                          |
 | `--version`         | Show the version number.                                                                                                                                                                   |                                          |
 
@@ -117,6 +119,18 @@ npx ghactivities scan ./out --provider google --output ./report.md
 ```
 
 You pass either a **file** or a **directory**. When a directory is given, every `*.json` file inside it is read and scanned together. By default the report is printed to stdout; pass `--output` to write it to a file instead.
+
+### One-stop collect and scan
+
+You can also collect and scan in a single run by adding `--scan` to the normal command. The same provider options (`--provider`, `--model`, `--api-key`, `--vertex-project`, `--vertex-location`) apply, and `--scan-output` writes the report to a file instead of stdout:
+
+```bash
+# Collect the last two weeks and immediately scan the result
+npx ghactivities --scan --provider openai
+
+# Collect, then write both the JSON and the report to files
+npx ghactivities --output ./activity.json --scan --provider google --scan-output ./report.md
+```
 
 ### Providers and API keys
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Fetches the following events authored by you within a date range and outputs the
 - **PullRequestComment** — comments you left on pull requests
 - **Commit** — commits you authored (on each repository's default branch)
 
+It can also **scan** the collected JSON with an LLM to produce a Markdown summary report — see [Scanning activity with an LLM](#scanning-activity-with-an-llm).
+
 ## Requirements
 
 - Node.js >= 20
@@ -97,7 +99,49 @@ npx ghactivities \
 
 # Write to a custom file, newest first, splitting at 500 KB
 npx ghactivities --output ./activity.json --order desc --max-length-size 500K
+
+# Scan the collected activity with an LLM and print a Markdown report
+npx ghactivities scan ./ghactivities.json --provider openai
 ```
+
+## Scanning activity with an LLM
+
+The `scan` subcommand reads the JSON produced by `ghactivities` and asks a large language model (via the [Vercel AI SDK](https://ai-sdk.dev/)) to summarize your activity into a Markdown report.
+
+```bash
+# Scan a single file
+npx ghactivities scan ./ghactivities.json
+
+# Scan a directory (every *.json file inside it is read)
+npx ghactivities scan ./out --provider google --output ./report.md
+```
+
+You pass either a **file** or a **directory**. When a directory is given, every `*.json` file inside it is read and scanned together. By default the report is printed to stdout; pass `--output` to write it to a file instead.
+
+### Providers and API keys
+
+The `--provider` option selects the LLM provider. The API key is resolved from the `--api-key` option, falling back to a provider-specific environment variable:
+
+| Provider (`--provider`) | Default model        | API key environment variable                       |
+| ----------------------- | -------------------- | -------------------------------------------------- |
+| `openai`                | `gpt-4o-mini`        | `OPENAI_API_KEY`                                   |
+| `google`                | `gemini-2.0-flash`   | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
+| `vertexai`              | `gemini-2.0-flash`   | `GOOGLE_VERTEX_API_KEY`                            |
+| `openrouter`            | `openai/gpt-4o-mini` | `OPENROUTER_API_KEY`                               |
+
+For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vertex-project` / `--vertex-location` (or the `GOOGLE_VERTEX_PROJECT` / `GOOGLE_VERTEX_LOCATION` environment variables).
+
+### Scan options
+
+| Option              | Description                                                                   | Default                      |
+| ------------------- | ----------------------------------------------------------------------------- | ---------------------------- |
+| `<dir or file>`     | Path to an activities JSON file or a directory of them (positional argument). | (required)                   |
+| `--provider`        | LLM provider: `openai`, `google`, `vertexai`, `openrouter`.                   | `openai`                     |
+| `--model`           | Model id.                                                                     | depends on the provider      |
+| `--api-key`         | API key for the provider.                                                     | provider env var (above)     |
+| `--output`          | Write the report to this file instead of stdout.                              | stdout                       |
+| `--vertex-project`  | Google Vertex project (provider `vertexai`).                                  | `GOOGLE_VERTEX_PROJECT` env  |
+| `--vertex-location` | Google Vertex location (provider `vertexai`).                                 | `GOOGLE_VERTEX_LOCATION` env |
 
 ## Notes
 

--- a/cspell.json
+++ b/cspell.json
@@ -91,6 +91,7 @@
     "lilconfig",
     "lintstagedrc",
     "listr",
+    "lockfiles",
     "loongarch",
     "Microbundle",
     "microtask",

--- a/cspell.json
+++ b/cspell.json
@@ -155,6 +155,7 @@
     "typer",
     "unpipe",
     "venv",
+    "vertexai",
     "vite",
     "vuepress",
     "weakmap",

--- a/cspell.json
+++ b/cspell.json
@@ -154,6 +154,7 @@
     "tsgo",
     "typer",
     "unpipe",
+    "unstub",
     "venv",
     "vertexai",
     "vite",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,14 @@
 		"pre-commit": "pnpm exec lint-staged"
 	},
 	"dependencies": {
+		"@ai-sdk/google": "4.0.10",
+		"@ai-sdk/google-vertex": "5.0.13",
+		"@ai-sdk/openai": "4.0.9",
 		"@clack/prompts": "1.0.0",
 		"@octokit/graphql": "9.0.3",
 		"@octokit/rest": "22.0.1",
+		"@openrouter/ai-sdk-provider": "3.0.0",
+		"ai": "7.0.18",
 		"js-tiktoken": "^1.0.21",
 		"zod": "4.3.6"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/google':
+        specifier: 4.0.10
+        version: 4.0.10(zod@4.3.6)
+      '@ai-sdk/google-vertex':
+        specifier: 5.0.13
+        version: 5.0.13(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: 4.0.9
+        version: 4.0.9(zod@4.3.6)
       '@clack/prompts':
         specifier: 1.0.0
         version: 1.0.0
@@ -17,6 +26,12 @@ importers:
       '@octokit/rest':
         specifier: 22.0.1
         version: 22.0.1
+      '@openrouter/ai-sdk-provider':
+        specifier: 3.0.0
+        version: 3.0.0(ai@7.0.18(zod@4.3.6))(zod@4.3.6)
+      ai:
+        specifier: 7.0.18
+        version: 7.0.18(zod@4.3.6)
       js-tiktoken:
         specifier: ^1.0.21
         version: 1.0.21
@@ -80,6 +95,52 @@ importers:
         version: 4.0.18(@types/node@25.2.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
 packages:
+
+  '@ai-sdk/anthropic@4.0.10':
+    resolution: {integrity: sha512-L9GlJyL8stPyv5QTRONnVoRVw82b6iBuX4LTiRJMM++I2RfDe+yrBsPa6gz6Msll9GZ7JsX0MRNUP4G1afjDTw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.14':
+    resolution: {integrity: sha512-wbYqQKpASsuK7bdoa1fp+QA6oy3ddqqBOukN3IkyaR8PAp0pWoc66ch2td+ixeknoCcO4F6VTkSFKVC6MP3bTQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google-vertex@5.0.13':
+    resolution: {integrity: sha512-WtAv5YsuwvxjqxwmRO0yTHGcz+QI2PZHHo0/lP5gveqOEs2GDU4ihLZrq+KJ5u+hfeEKRlIB5XHTenV3rcvCzg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@4.0.10':
+    resolution: {integrity: sha512-+g629pKE4xhLB6LnskHlOkie30UENhiKpdYMGQoGYm09191kfRU8qAU7wgF01PmzGFe0h3JYpls6Ok2aCYmjzQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.6':
+    resolution: {integrity: sha512-1YB8Wt2l3X1gCLuF5bYoaQn04XXw+GKqxSvnHAnGEpK+xflJfnJ1l93KHbijLBObM6KAC7amKT9KjM9iu1B6zA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.9':
+    resolution: {integrity: sha512-j7x7FC6KQJMQaJoi6hFLzbB2aXMnR+IA8h0BQH8YCbQESppbM7SzmZ4VAPpobIvx0rqiVNJ1JjraElOLuA31Ag==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.6':
+    resolution: {integrity: sha512-i4mVayGtC+HrRmtfPFOxvKKQgFU+1dwTTsh4MY0jY1MaGuppOwDFrNYrJ3dDXWMkO3o6FDVAKY8ZDsy7hLsO9Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.2':
+    resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
+    engines: {node: '>=22'}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -802,6 +863,13 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@openrouter/ai-sdk-provider@3.0.0':
+    resolution: {integrity: sha512-m9XTSWoODH2RM5OsZpaGiN7QRR8cdP5paBWq699Tu3JVmGPBKT8xF8XwV0ZBVVsjikD/JgWfak4VSsTR4wAVbg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      ai: ^7.0.0
+      zod: ^3.25.76 || ^4.1.8
+
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1510,6 +1578,10 @@ packages:
     peerDependencies:
       valibot: ^1.4.0
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
     peerDependencies:
@@ -1548,6 +1620,9 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1559,6 +1634,16 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ai@7.0.18:
+    resolution: {integrity: sha512-/DsiRfbLPtoHf9C47Hy+LK+HkjNowX1DQo3id4zWegfU6z1WjVDRAHYJAiX7SXhGp0mWX4tcenUhfIFessDWnw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1631,6 +1716,9 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binaryextensions@6.11.0:
     resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
     engines: {node: '>=4'}
@@ -1648,6 +1736,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1804,6 +1895,10 @@ packages:
     engines: {node: '>=20.18'}
     hasBin: true
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1858,6 +1953,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   editions@6.22.0:
     resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
@@ -1978,6 +2076,9 @@ packages:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -2023,6 +2124,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -2060,6 +2165,10 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2083,6 +2192,14 @@ packages:
   fuse.js@7.4.2:
     resolution: {integrity: sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==}
     engines: {node: '>=10'}
+
+  gaxios@7.1.6:
+    resolution: {integrity: sha512-aIQ0QL8Or8vsUhHyXGA6AohOFRrAAiHhrvsAG6myzcSlfhxSXtnwXA/pRuQTilFgjhLe30swK5rg1d7E1f8Izw==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensequence@8.0.8:
     resolution: {integrity: sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==}
@@ -2133,6 +2250,14 @@ packages:
   globby@16.2.0:
     resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
     engines: {node: '>=20'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2187,6 +2312,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-readable-ids@1.0.4:
     resolution: {integrity: sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==}
@@ -2335,11 +2464,17 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
@@ -2351,6 +2486,12 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -2475,6 +2616,15 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -2720,6 +2870,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3166,6 +3319,10 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3243,6 +3400,61 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@ai-sdk/anthropic@4.0.10(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/gateway@4.0.14(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/google-vertex@5.0.13(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/anthropic': 4.0.10(zod@4.3.6)
+      '@ai-sdk/google': 4.0.10(zod@4.3.6)
+      '@ai-sdk/openai-compatible': 3.0.6(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      google-auth-library: 10.9.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ai-sdk/google@4.0.10(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/openai-compatible@3.0.6(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/openai@4.0.9(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@5.0.6(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider@4.0.2':
+    dependencies:
+      json-schema: 0.4.0
 
   '@azu/format-text@1.0.2': {}
 
@@ -3862,6 +4074,11 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.18(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      ai: 7.0.18(zod@4.3.6)
+      zod: 4.3.6
+
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     optional: true
 
@@ -4342,6 +4559,8 @@ snapshots:
     dependencies:
       valibot: 1.4.2(typescript@5.9.3)
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.2.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -4395,6 +4614,8 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0': {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -4410,6 +4631,15 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
+
+  ai@7.0.18(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.6(zod@4.3.6)
+      zod: 4.3.6
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -4478,6 +4708,8 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  bignumber.js@9.3.1: {}
+
   binaryextensions@6.11.0:
     dependencies:
       editions: 6.22.0
@@ -4503,6 +4735,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bytes@3.1.2: {}
 
@@ -4693,6 +4927,8 @@ snapshots:
       semver: 7.8.5
       tinyglobby: 0.2.17
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4724,6 +4960,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   editions@6.22.0:
     dependencies:
@@ -4910,6 +5150,8 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
+  extend@3.0.2: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -4966,6 +5208,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -5012,6 +5259,10 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -5024,6 +5275,22 @@ snapshots:
   function-bind@1.1.2: {}
 
   fuse.js@7.4.2: {}
+
+  gaxios@7.1.6:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.6
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensequence@8.0.8: {}
 
@@ -5090,6 +5357,19 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.6
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   gray-matter@4.0.3:
@@ -5145,6 +5425,13 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5258,15 +5545,32 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
 
   json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keygrip@1.1.0:
     dependencies:
@@ -5413,6 +5717,14 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -5757,6 +6069,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
@@ -6154,6 +6468,8 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   walk-up-path@4.0.0: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,11 @@ allowBuilds:
   tldjs: false
 minimumReleaseAgeExclude:
   - knip@6.25.0
+  - "@ai-sdk/anthropic@4.0.10"
+  - "@ai-sdk/gateway@4.0.14"
+  - "@ai-sdk/google-vertex@5.0.13"
+  - "@ai-sdk/google@4.0.10"
+  - "@ai-sdk/openai-compatible@3.0.6"
+  - "@ai-sdk/openai@4.0.9"
+  - "@ai-sdk/provider-utils@5.0.6"
+  - ai@7.0.18

--- a/src/cli/emit-scan-report.ts
+++ b/src/cli/emit-scan-report.ts
@@ -1,0 +1,16 @@
+import * as p from "@clack/prompts";
+import { writeFile } from "node:fs/promises";
+
+/** Write the scan report to a file when `output` is set, otherwise print it. */
+export async function emitScanReport(params: {
+  report: string;
+  output?: string | undefined;
+}): Promise<void> {
+  const { report, output } = params;
+  if (output) {
+    await writeFile(output, report, "utf-8");
+    p.log.success(`Report written to ${output}`);
+  } else {
+    p.log.message(report);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,8 +8,15 @@ import { writeEventsToFiles } from "../utils/file-writer.js";
 import { sortEvents } from "../utils/sort-events.js";
 import { resolveGitHubToken } from "../utils/token.js";
 import { parseCliArgs } from "./parse-args.js";
+import { runScan } from "./scan-command.js";
 
 async function main(): Promise<void> {
+  const [subcommand, ...rest] = process.argv.slice(2);
+  if (subcommand === "scan") {
+    await runScan(rest);
+    return;
+  }
+
   p.intro("ghactivities");
 
   let options;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,10 +3,12 @@
 import * as p from "@clack/prompts";
 
 import { GitHubService } from "../services/github.js";
+import { scanActivities } from "../services/scan.js";
 import { formatError } from "../utils/error.js";
 import { writeEventsToFiles } from "../utils/file-writer.js";
 import { sortEvents } from "../utils/sort-events.js";
 import { resolveGitHubToken } from "../utils/token.js";
+import { emitScanReport } from "./emit-scan-report.js";
 import { parseCliArgs } from "./parse-args.js";
 import { runScan } from "./scan-command.js";
 
@@ -55,6 +57,14 @@ async function main(): Promise<void> {
       maxTokens: options.maxTokens,
     });
     s.stop(`Written to ${files.join(", ")}`);
+
+    if (options.scan) {
+      s.start(`Scanning with ${options.scan.provider} (${options.scan.model})...`);
+      const content = JSON.stringify(sorted, null, 2);
+      const report = await scanActivities({ config: options.scan, content });
+      s.stop("Scan complete.");
+      await emitScanReport({ report, output: options.scan.output });
+    }
 
     p.outro(`Done! ${String(sorted.length)} events collected.`);
   } catch (error) {

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -43,6 +43,41 @@ describe("parseCliArgs", () => {
     expect(result.until).toBeInstanceOf(Date);
   });
 
+  it("leaves scan undefined unless --scan is passed", () => {
+    expect(parseCliArgs([]).scan).toBeUndefined();
+  });
+
+  it("resolves scan config when --scan is passed", () => {
+    const result = parseCliArgs([
+      "--scan",
+      "--provider",
+      "openrouter",
+      "--model",
+      "openai/gpt-4o",
+      "--api-key",
+      "sk-test",
+      "--scan-output",
+      "./report.md",
+    ]);
+    expect(result.scan).toEqual({
+      provider: "openrouter",
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+      output: "./report.md",
+      vertexProject: undefined,
+      vertexLocation: undefined,
+    });
+  });
+
+  it("throws when --scan is passed without a resolvable API key", () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    try {
+      expect(() => parseCliArgs(["--scan"])).toThrow(/api key/i);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("throws on invalid visibility", () => {
     expect(() => parseCliArgs(["--visibility", "invalid"])).toThrow();
   });

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -5,6 +5,7 @@ import type { CliOptions, Order, Visibility } from "../types/cli.js";
 
 import packageJson from "../../package.json" with { type: "json" };
 import { parseSize } from "../utils/parse-size.js";
+import { resolveScanConfig } from "./parse-scan-args.js";
 
 const ArgsSchema = z.object({
   githubToken: z.optional(z.string()),
@@ -64,6 +65,13 @@ export function parseCliArgs(argv: string[]): CliOptions {
       "max-length-size": { type: "string", default: "1M" },
       "max-tokens": { type: "string" },
       order: { type: "string", default: "asc" },
+      scan: { type: "boolean", default: false },
+      provider: { type: "string" },
+      model: { type: "string" },
+      "api-key": { type: "string" },
+      "scan-output": { type: "string" },
+      "vertex-project": { type: "string" },
+      "vertex-location": { type: "string" },
       help: { type: "boolean", default: false },
       version: { type: "boolean", default: false },
     },
@@ -91,6 +99,17 @@ export function parseCliArgs(argv: string[]): CliOptions {
     order: values.order,
   });
 
+  const scan = values.scan
+    ? resolveScanConfig({
+        provider: values.provider,
+        model: values.model,
+        apiKey: values["api-key"],
+        output: values["scan-output"],
+        vertexProject: values["vertex-project"],
+        vertexLocation: values["vertex-location"],
+      })
+    : undefined;
+
   return {
     githubToken: parsed.githubToken ?? "",
     output: parsed.output,
@@ -100,6 +119,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     maxLengthSize: parseSize(parsed.maxLengthSize),
     maxTokens: parsed.maxTokens === undefined ? undefined : Number(parsed.maxTokens.trim()),
     order: parsed.order as Order,
+    scan,
   };
 }
 
@@ -117,16 +137,18 @@ Options:
   --max-length-size   Max output file size: e.g., 1B, 2K, 2M (default: 1M)
   --max-tokens        Max tokens per output file (js-tiktoken, cl100k_base); splits when exceeded
   --order             Event order: asc, desc (default: asc)
+  --scan              After collecting, scan the output with an LLM (see scan options)
+  --scan-output       With --scan, write the report to this file instead of stdout
   --help              Show this help message
   --version           Show the version number
 
-scan options (ghactivities scan <dir or file>):
+scan options (used by "ghactivities scan <dir or file>" and by --scan):
   Scan collected activity JSON with an LLM and print a Markdown report.
   --provider          LLM provider: openai, google, vertexai, openrouter (default: openai)
   --model             Model id (default depends on the provider)
   --api-key           API key (env: OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY,
                       GOOGLE_VERTEX_API_KEY, or OPENROUTER_API_KEY by provider)
-  --output            Write the report to this file instead of stdout
+  --output            (scan subcommand only) write the report to this file instead of stdout
   --vertex-project    Google Vertex project (provider: vertexai)
   --vertex-location   Google Vertex location (provider: vertexai)
 `);

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -106,6 +106,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
 function printHelp(): void {
   console.log(`
 Usage: ghactivities [options]
+       ghactivities scan <dir or file> [scan options]
 
 Options:
   --github-token      GitHub access token (env: GITHUB_TOKEN or "gh auth token")
@@ -118,5 +119,15 @@ Options:
   --order             Event order: asc, desc (default: asc)
   --help              Show this help message
   --version           Show the version number
+
+scan options (ghactivities scan <dir or file>):
+  Scan collected activity JSON with an LLM and print a Markdown report.
+  --provider          LLM provider: openai, google, vertexai, openrouter (default: openai)
+  --model             Model id (default depends on the provider)
+  --api-key           API key (env: OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY,
+                      GOOGLE_VERTEX_API_KEY, or OPENROUTER_API_KEY by provider)
+  --output            Write the report to this file instead of stdout
+  --vertex-project    Google Vertex project (provider: vertexai)
+  --vertex-location   Google Vertex location (provider: vertexai)
 `);
 }

--- a/src/cli/parse-scan-args.test.ts
+++ b/src/cli/parse-scan-args.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { parseScanArgs } from "./parse-scan-args.js";
+
+describe("parseScanArgs", () => {
+  it("parses a path with explicit options", () => {
+    const result = parseScanArgs(
+      [
+        "./ghactivities.json",
+        "--provider",
+        "openrouter",
+        "--model",
+        "openai/gpt-4o",
+        "--api-key",
+        "sk-test",
+        "--output",
+        "./report.md",
+      ],
+      {},
+    );
+    expect(result.path).toBe("./ghactivities.json");
+    expect(result.provider).toBe("openrouter");
+    expect(result.model).toBe("openai/gpt-4o");
+    expect(result.apiKey).toBe("sk-test");
+    expect(result.output).toBe("./report.md");
+  });
+
+  it("defaults the provider to openai and picks its default model", () => {
+    const result = parseScanArgs(["./out.json"], { OPENAI_API_KEY: "sk-env" });
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-4o-mini");
+    expect(result.apiKey).toBe("sk-env");
+  });
+
+  it("resolves the API key from a provider-specific env var", () => {
+    const result = parseScanArgs(["./out.json", "--provider", "google"], {
+      GEMINI_API_KEY: "gk-env",
+    });
+    expect(result.apiKey).toBe("gk-env");
+  });
+
+  it("prefers --api-key over env vars", () => {
+    const result = parseScanArgs(["./out.json", "--api-key", "flag"], {
+      OPENAI_API_KEY: "env",
+    });
+    expect(result.apiKey).toBe("flag");
+  });
+
+  it("carries Vertex project and location", () => {
+    const result = parseScanArgs(
+      [
+        "./out.json",
+        "--provider",
+        "vertexai",
+        "--api-key",
+        "k",
+        "--vertex-project",
+        "my-proj",
+        "--vertex-location",
+        "us-central1",
+      ],
+      {},
+    );
+    expect(result.vertexProject).toBe("my-proj");
+    expect(result.vertexLocation).toBe("us-central1");
+  });
+
+  it("throws when the path is missing", () => {
+    expect(() => parseScanArgs([], { OPENAI_API_KEY: "k" })).toThrow(/path/i);
+  });
+
+  it("throws on an invalid provider", () => {
+    expect(() => parseScanArgs(["./out.json", "--provider", "nope"], {})).toThrow();
+  });
+
+  it("throws when no API key can be resolved", () => {
+    expect(() => parseScanArgs(["./out.json"], {})).toThrow(/api key/i);
+  });
+
+  it("throws on extra positional arguments", () => {
+    expect(() => parseScanArgs(["a", "b"], { OPENAI_API_KEY: "k" })).toThrow(/extra/i);
+  });
+});

--- a/src/cli/parse-scan-args.ts
+++ b/src/cli/parse-scan-args.ts
@@ -1,0 +1,78 @@
+import { parseArgs as nodeParseArgs } from "node:util";
+import { z } from "zod/mini";
+
+import type { ScanOptions, ScanProvider } from "../types/scan.js";
+
+const ProviderSchema = z.enum(["openai", "google", "vertexai", "openrouter"]);
+
+const DEFAULT_MODELS: Record<ScanProvider, string> = {
+  openai: "gpt-4o-mini",
+  google: "gemini-2.0-flash",
+  vertexai: "gemini-2.0-flash",
+  openrouter: "openai/gpt-4o-mini",
+};
+
+// Provider-specific environment variables consulted, in order, when
+// --api-key is not passed.
+const API_KEY_ENV_VARS: Record<ScanProvider, string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  google: ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
+  vertexai: ["GOOGLE_VERTEX_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+};
+
+function resolveApiKey(params: {
+  provider: ScanProvider;
+  apiKeyOption: string | undefined;
+  env: NodeJS.ProcessEnv;
+}): string {
+  const { provider, apiKeyOption, env } = params;
+  if (apiKeyOption) {
+    return apiKeyOption;
+  }
+  for (const name of API_KEY_ENV_VARS[provider]) {
+    const value = env[name];
+    if (value) {
+      return value;
+    }
+  }
+  const names = API_KEY_ENV_VARS[provider].join(" or ");
+  throw new Error(`Missing API key for provider "${provider}". Pass --api-key or set ${names}.`);
+}
+
+export function parseScanArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): ScanOptions {
+  const { values, positionals } = nodeParseArgs({
+    args: argv,
+    options: {
+      provider: { type: "string", default: "openai" },
+      model: { type: "string" },
+      "api-key": { type: "string" },
+      output: { type: "string" },
+      "vertex-project": { type: "string" },
+      "vertex-location": { type: "string" },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+
+  const path = positionals[0];
+  if (path === undefined) {
+    throw new Error("Missing path. Usage: ghactivities scan <dir or file> [options]");
+  }
+  if (positionals.length > 1) {
+    throw new Error(`Unexpected extra arguments: ${positionals.slice(1).join(", ")}`);
+  }
+
+  const provider = ProviderSchema.parse(values.provider) as ScanProvider;
+  const apiKey = resolveApiKey({ provider, apiKeyOption: values["api-key"], env });
+
+  return {
+    path,
+    provider,
+    model: values.model ?? DEFAULT_MODELS[provider],
+    apiKey,
+    output: values.output,
+    vertexProject: values["vertex-project"],
+    vertexLocation: values["vertex-location"],
+  };
+}

--- a/src/cli/parse-scan-args.ts
+++ b/src/cli/parse-scan-args.ts
@@ -1,7 +1,7 @@
 import { parseArgs as nodeParseArgs } from "node:util";
 import { z } from "zod/mini";
 
-import type { ScanOptions, ScanProvider } from "../types/scan.js";
+import type { ScanConfig, ScanOptions, ScanProvider } from "../types/scan.js";
 
 const ProviderSchema = z.enum(["openai", "google", "vertexai", "openrouter"]);
 
@@ -40,6 +40,35 @@ function resolveApiKey(params: {
   throw new Error(`Missing API key for provider "${provider}". Pass --api-key or set ${names}.`);
 }
 
+/**
+ * Resolve the shared scan configuration (provider, model, API key, output, and
+ * Vertex settings) from raw option values. Used by both the `scan` subcommand
+ * and the collect command's `--scan` option.
+ */
+export function resolveScanConfig(params: {
+  provider: string | undefined;
+  model: string | undefined;
+  apiKey: string | undefined;
+  output: string | undefined;
+  vertexProject: string | undefined;
+  vertexLocation: string | undefined;
+  env?: NodeJS.ProcessEnv;
+}): ScanConfig {
+  const { provider: providerOption, model, apiKey, output, vertexProject, vertexLocation } = params;
+  const env = params.env ?? process.env;
+
+  const provider = ProviderSchema.parse(providerOption ?? "openai") as ScanProvider;
+
+  return {
+    provider,
+    model: model ?? DEFAULT_MODELS[provider],
+    apiKey: resolveApiKey({ provider, apiKeyOption: apiKey, env }),
+    output,
+    vertexProject,
+    vertexLocation,
+  };
+}
+
 export function parseScanArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): ScanOptions {
   const { values, positionals } = nodeParseArgs({
     args: argv,
@@ -63,16 +92,15 @@ export function parseScanArgs(argv: string[], env: NodeJS.ProcessEnv = process.e
     throw new Error(`Unexpected extra arguments: ${positionals.slice(1).join(", ")}`);
   }
 
-  const provider = ProviderSchema.parse(values.provider) as ScanProvider;
-  const apiKey = resolveApiKey({ provider, apiKeyOption: values["api-key"], env });
-
-  return {
-    path,
-    provider,
-    model: values.model ?? DEFAULT_MODELS[provider],
-    apiKey,
+  const config = resolveScanConfig({
+    provider: values.provider,
+    model: values.model,
+    apiKey: values["api-key"],
     output: values.output,
     vertexProject: values["vertex-project"],
     vertexLocation: values["vertex-location"],
-  };
+    env,
+  });
+
+  return { path, ...config };
 }

--- a/src/cli/scan-command.ts
+++ b/src/cli/scan-command.ts
@@ -1,9 +1,9 @@
 import * as p from "@clack/prompts";
-import { writeFile } from "node:fs/promises";
 
 import { scanActivities } from "../services/scan.js";
 import { formatError } from "../utils/error.js";
 import { readActivities } from "../utils/read-activities.js";
+import { emitScanReport } from "./emit-scan-report.js";
 import { parseScanArgs } from "./parse-scan-args.js";
 
 export async function runScan(argv: string[]): Promise<void> {
@@ -25,16 +25,11 @@ export async function runScan(argv: string[]): Promise<void> {
     s.stop(`Read ${String(files.length)} file(s).`);
 
     s.start(`Scanning with ${options.provider} (${options.model})...`);
-    const report = await scanActivities({ options, content });
+    const report = await scanActivities({ config: options, content });
     s.stop("Scan complete.");
 
-    if (options.output) {
-      await writeFile(options.output, report, "utf-8");
-      p.outro(`Report written to ${options.output}`);
-    } else {
-      p.log.message(report);
-      p.outro("Done!");
-    }
+    await emitScanReport({ report, output: options.output });
+    p.outro("Done!");
   } catch (error) {
     s.stop("Failed.");
     p.log.error(formatError(error));

--- a/src/cli/scan-command.ts
+++ b/src/cli/scan-command.ts
@@ -1,0 +1,43 @@
+import * as p from "@clack/prompts";
+import { writeFile } from "node:fs/promises";
+
+import { scanActivities } from "../services/scan.js";
+import { formatError } from "../utils/error.js";
+import { readActivities } from "../utils/read-activities.js";
+import { parseScanArgs } from "./parse-scan-args.js";
+
+export async function runScan(argv: string[]): Promise<void> {
+  p.intro("ghactivities scan");
+
+  let options;
+  try {
+    options = parseScanArgs(argv);
+  } catch (error) {
+    p.log.error(`Invalid arguments: ${formatError(error)}`);
+    process.exit(1);
+  }
+
+  const s = p.spinner();
+
+  try {
+    s.start(`Reading activities from ${options.path}...`);
+    const { files, content } = await readActivities({ path: options.path });
+    s.stop(`Read ${String(files.length)} file(s).`);
+
+    s.start(`Scanning with ${options.provider} (${options.model})...`);
+    const report = await scanActivities({ options, content });
+    s.stop("Scan complete.");
+
+    if (options.output) {
+      await writeFile(options.output, report, "utf-8");
+      p.outro(`Report written to ${options.output}`);
+    } else {
+      p.log.message(report);
+      p.outro("Done!");
+    }
+  } catch (error) {
+    s.stop("Failed.");
+    p.log.error(formatError(error));
+    process.exit(1);
+  }
+}

--- a/src/e2e/e2e-helper.ts
+++ b/src/e2e/e2e-helper.ts
@@ -35,11 +35,15 @@ function resolveRunner(): { cmd: string; baseArgs: string[] } {
 
 const { cmd: ghCmd, baseArgs: ghArgs } = resolveRunner();
 
-/** Run the ghactivities CLI with args, returning { stdout, stderr }. */
-export function runCli(args: string[], opts: { cwd?: string } = {}) {
+/**
+ * Run the ghactivities CLI with args, returning { stdout, stderr }. Values in
+ * `opts.env` are merged on top of the current environment (pass an empty string
+ * to force-unset a variable such as an API key).
+ */
+export function runCli(args: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
   return execFileAsync(ghCmd, [...ghArgs, ...args], {
     cwd: opts.cwd ?? process.cwd(),
-    env: { ...process.env },
+    env: { ...process.env, ...opts.env },
   });
 }
 

--- a/src/e2e/e2e-scan.spec.ts
+++ b/src/e2e/e2e-scan.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli, useTestDirectory } from "./e2e-helper.js";
+
+// The scan subcommand reports errors through @clack/prompts, which writes to
+// stdout (not stderr) and exits non-zero. These cases all resolve before any
+// LLM API call is made, so they need no network access or real API key.
+describe("E2E: scan subcommand", () => {
+  useTestDirectory();
+
+  it("rejects a missing path", async () => {
+    await expect(runCli(["scan", "--api-key", "k"])).rejects.toMatchObject({
+      stdout: expect.stringMatching(/path/i),
+    });
+  });
+
+  it("rejects an invalid --provider value", async () => {
+    await expect(
+      runCli(["scan", "./ghactivities.json", "--provider", "bogus", "--api-key", "k"]),
+    ).rejects.toMatchObject({
+      stdout: expect.stringMatching(/provider|invalid/i),
+    });
+  });
+
+  it("rejects when no API key can be resolved", async () => {
+    // Force-unset the OpenAI key (the default provider) so resolution fails.
+    await expect(
+      runCli(["scan", "./ghactivities.json"], { env: { OPENAI_API_KEY: "" } }),
+    ).rejects.toMatchObject({
+      stdout: expect.stringMatching(/api key/i),
+    });
+  });
+
+  it("fails when the activities file does not exist", async () => {
+    await expect(runCli(["scan", "./does-not-exist.json", "--api-key", "k"])).rejects.toMatchObject(
+      {
+        stdout: expect.stringMatching(/does-not-exist|ENOENT|no such file/i),
+      },
+    );
+  });
+});

--- a/src/e2e/e2e-scan.spec.ts
+++ b/src/e2e/e2e-scan.spec.ts
@@ -38,4 +38,18 @@ describe("E2E: scan subcommand", () => {
       },
     );
   });
+
+  it("rejects --scan on the collect command with an invalid provider", async () => {
+    await expect(runCli(["--scan", "--provider", "bogus", "--api-key", "k"])).rejects.toMatchObject(
+      {
+        stdout: expect.stringMatching(/provider|invalid/i),
+      },
+    );
+  });
+
+  it("rejects --scan on the collect command with no resolvable API key", async () => {
+    await expect(runCli(["--scan"], { env: { OPENAI_API_KEY: "" } })).rejects.toMatchObject({
+      stdout: expect.stringMatching(/api key/i),
+    });
+  });
 });

--- a/src/services/scan.test.ts
+++ b/src/services/scan.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScanProvider } from "../types/scan.js";
+
+import { buildModel } from "./scan.js";
+
+describe("buildModel", () => {
+  const cases: { provider: ScanProvider; model: string }[] = [
+    { provider: "openai", model: "gpt-4o-mini" },
+    { provider: "google", model: "gemini-2.0-flash" },
+    { provider: "vertexai", model: "gemini-2.0-flash" },
+    { provider: "openrouter", model: "openai/gpt-4o-mini" },
+  ];
+
+  for (const { provider, model } of cases) {
+    it(`builds a language model for ${provider}`, () => {
+      const result = buildModel({
+        provider,
+        model,
+        apiKey: "test-key",
+        vertexProject: "proj",
+        vertexLocation: "us-central1",
+      });
+      expect(result).toBeDefined();
+      expect(typeof result).toBe("object");
+    });
+  }
+});

--- a/src/services/scan.ts
+++ b/src/services/scan.ts
@@ -1,0 +1,70 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createVertex } from "@ai-sdk/google-vertex";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { generateText, type LanguageModel } from "ai";
+
+import type { ScanOptions } from "../types/scan.js";
+
+const SYSTEM_PROMPT = `You are an assistant that reviews a developer's GitHub activity.
+The user provides a JSON export of their activity (issues, issue comments, discussions,
+discussion comments, pull requests, pull request comments, and commits).
+Analyze it and produce a concise report in Markdown that includes:
+- A short overall summary of what the developer worked on.
+- The main themes or projects, grouped by repository when useful.
+- Notable pull requests, issues, or discussions worth highlighting.
+Be factual and only rely on the provided data.`;
+
+/** Build a Vercel AI SDK language model for the configured provider. */
+export function buildModel(params: {
+  provider: ScanOptions["provider"];
+  model: string;
+  apiKey: string;
+  vertexProject?: string | undefined;
+  vertexLocation?: string | undefined;
+}): LanguageModel {
+  const { provider, model, apiKey, vertexProject, vertexLocation } = params;
+
+  switch (provider) {
+    case "openai":
+      return createOpenAI({ apiKey })(model);
+    case "google":
+      return createGoogleGenerativeAI({ apiKey })(model);
+    case "vertexai": {
+      const settings: Parameters<typeof createVertex>[0] = { apiKey };
+      if (vertexProject !== undefined) {
+        settings.project = vertexProject;
+      }
+      if (vertexLocation !== undefined) {
+        settings.location = vertexLocation;
+      }
+      return createVertex(settings)(model);
+    }
+    case "openrouter":
+      return createOpenRouter({ apiKey })(model);
+  }
+}
+
+/** Scan the given activity content with the configured LLM and return a report. */
+export async function scanActivities(params: {
+  options: ScanOptions;
+  content: string;
+}): Promise<string> {
+  const { options, content } = params;
+
+  const model = buildModel({
+    provider: options.provider,
+    model: options.model,
+    apiKey: options.apiKey,
+    vertexProject: options.vertexProject,
+    vertexLocation: options.vertexLocation,
+  });
+
+  const { text } = await generateText({
+    model,
+    system: SYSTEM_PROMPT,
+    prompt: `Here is the GitHub activity to analyze:\n\n${content}`,
+  });
+
+  return text;
+}

--- a/src/services/scan.ts
+++ b/src/services/scan.ts
@@ -4,7 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText, type LanguageModel } from "ai";
 
-import type { ScanOptions } from "../types/scan.js";
+import type { ScanConfig } from "../types/scan.js";
 
 const SYSTEM_PROMPT = `You are an assistant that reviews a developer's GitHub activity.
 The user provides a JSON export of their activity (issues, issue comments, discussions,
@@ -17,7 +17,7 @@ Be factual and only rely on the provided data.`;
 
 /** Build a Vercel AI SDK language model for the configured provider. */
 export function buildModel(params: {
-  provider: ScanOptions["provider"];
+  provider: ScanConfig["provider"];
   model: string;
   apiKey: string;
   vertexProject?: string | undefined;
@@ -47,17 +47,17 @@ export function buildModel(params: {
 
 /** Scan the given activity content with the configured LLM and return a report. */
 export async function scanActivities(params: {
-  options: ScanOptions;
+  config: ScanConfig;
   content: string;
 }): Promise<string> {
-  const { options, content } = params;
+  const { config, content } = params;
 
   const model = buildModel({
-    provider: options.provider,
-    model: options.model,
-    apiKey: options.apiKey,
-    vertexProject: options.vertexProject,
-    vertexLocation: options.vertexLocation,
+    provider: config.provider,
+    model: config.model,
+    apiKey: config.apiKey,
+    vertexProject: config.vertexProject,
+    vertexLocation: config.vertexLocation,
   });
 
   const { text } = await generateText({

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,3 +1,5 @@
+import type { ScanConfig } from "./scan.js";
+
 export type Visibility = "public" | "private" | "all";
 export type Order = "asc" | "desc";
 
@@ -10,4 +12,6 @@ export interface CliOptions {
   maxLengthSize: number;
   maxTokens?: number | undefined;
   order: Order;
+  /** When set (via --scan), the collected output is scanned with an LLM. */
+  scan?: ScanConfig | undefined;
 }

--- a/src/types/scan.ts
+++ b/src/types/scan.ts
@@ -1,0 +1,16 @@
+export type ScanProvider = "openai" | "google" | "vertexai" | "openrouter";
+
+export interface ScanOptions {
+  /** Path to an activities JSON file or a directory containing them. */
+  path: string;
+  provider: ScanProvider;
+  model: string;
+  /** Resolved API key (from --api-key or a provider-specific env var). */
+  apiKey: string;
+  /** When set, the report is written here; otherwise it is printed to stdout. */
+  output?: string | undefined;
+  /** Google Vertex project (only used when provider is "vertexai"). */
+  vertexProject?: string | undefined;
+  /** Google Vertex location (only used when provider is "vertexai"). */
+  vertexLocation?: string | undefined;
+}

--- a/src/types/scan.ts
+++ b/src/types/scan.ts
@@ -1,8 +1,6 @@
 export type ScanProvider = "openai" | "google" | "vertexai" | "openrouter";
 
-export interface ScanOptions {
-  /** Path to an activities JSON file or a directory containing them. */
-  path: string;
+export interface ScanConfig {
   provider: ScanProvider;
   model: string;
   /** Resolved API key (from --api-key or a provider-specific env var). */
@@ -13,4 +11,9 @@ export interface ScanOptions {
   vertexProject?: string | undefined;
   /** Google Vertex location (only used when provider is "vertexai"). */
   vertexLocation?: string | undefined;
+}
+
+export interface ScanOptions extends ScanConfig {
+  /** Path to an activities JSON file or a directory containing them. */
+  path: string;
 }

--- a/src/utils/read-activities.test.ts
+++ b/src/utils/read-activities.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readActivities } from "./read-activities.js";
+
+describe("readActivities", () => {
+  let dir = "";
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "read-activities-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reads a single file", async () => {
+    const file = join(dir, "ghactivities.json");
+    await writeFile(file, '[{"type":"Issue"}]', "utf-8");
+
+    const result = await readActivities({ path: file });
+    expect(result.files).toEqual([file]);
+    expect(result.content).toContain('"type":"Issue"');
+  });
+
+  it("reads every .json file in a directory, sorted", async () => {
+    await writeFile(join(dir, "b.json"), '["b"]', "utf-8");
+    await writeFile(join(dir, "a.json"), '["a"]', "utf-8");
+    await writeFile(join(dir, "note.txt"), "ignored", "utf-8");
+
+    const result = await readActivities({ path: dir });
+    expect(result.files).toEqual([join(dir, "a.json"), join(dir, "b.json")]);
+    expect(result.content).toContain('["a"]');
+    expect(result.content).toContain('["b"]');
+    expect(result.content).not.toContain("ignored");
+  });
+
+  it("throws when a directory has no .json files", async () => {
+    await writeFile(join(dir, "note.txt"), "x", "utf-8");
+    await expect(readActivities({ path: dir })).rejects.toThrow(/no .json files/i);
+  });
+
+  it("rejects when the path does not exist", async () => {
+    await expect(readActivities({ path: join(dir, "missing.json") })).rejects.toThrow();
+  });
+});

--- a/src/utils/read-activities.ts
+++ b/src/utils/read-activities.ts
@@ -1,0 +1,42 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface ReadActivitiesResult {
+  /** The files that were read, in the order they were concatenated. */
+  files: string[];
+  /** The concatenated raw contents of every file that was read. */
+  content: string;
+}
+
+/**
+ * Read activity data from a single file or from every `*.json` file inside a
+ * directory. The raw file contents are concatenated so they can be handed to an
+ * LLM for scanning.
+ */
+export async function readActivities(params: { path: string }): Promise<ReadActivitiesResult> {
+  const { path } = params;
+  const stats = await stat(path);
+
+  const files = stats.isDirectory() ? await listJsonFiles({ dir: path }) : [path];
+  if (files.length === 0) {
+    throw new Error(`No .json files found in directory: ${path}`);
+  }
+
+  const parts = await Promise.all(
+    files.map(async (file) => {
+      const text = await readFile(file, "utf-8");
+      return `# ${file}\n${text}`;
+    }),
+  );
+
+  return { files, content: parts.join("\n\n") };
+}
+
+async function listJsonFiles(params: { dir: string }): Promise<string[]> {
+  const { dir } = params;
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => join(dir, entry.name))
+    .toSorted((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
## Summary

Three additions:

### 1. `ghactivities scan <dir or file>` subcommand
Reads collected activity JSON and summarizes it into a Markdown report via the [Vercel AI SDK](https://ai-sdk.dev/).
- Accepts a single JSON file or a directory (every `*.json` inside is read together).
- Providers via `--provider`: `openai`, `google` (Gemini), `vertexai` (Vertex AI express mode), `openrouter`.
- API key from `--api-key`, falling back to a provider-specific env var (`OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`/`GEMINI_API_KEY`, `GOOGLE_VERTEX_API_KEY`, `OPENROUTER_API_KEY`).
- `--model` overrides the per-provider default; `--output` writes the report to a file; `--vertex-project`/`--vertex-location` for Vertex.

### 2. `--scan` one-stop option on the collect command
Runs the LLM scan immediately after collecting, in a single invocation. Reuses the shared provider config; `--scan-output` writes the report to a file instead of stdout. Scan config resolution is shared via `resolveScanConfig`.

### 3. `/goal-pr` rulesync command
Adds `.rulesync/commands/goal-pr.md` (adapted from dyoshikawa/rulesync): drives a PR to merge by looping /review-pr → fix mid-or-above findings → merge once clean and CI is green. Generated `.claude`/`.opencode` outputs are gitignored, so only the `.rulesync` source is tracked.

## Test plan
- Unit tests: `parse-scan-args`/`resolveScanConfig`, `read-activities`, `buildModel` per provider, `parseCliArgs` `--scan` resolution.
- E2E (`src/e2e/e2e-scan.spec.ts`): missing path, invalid provider, missing API key, missing file, and the collect `--scan` validation paths — all resolve before any network call.
- Manual smoke test: `scan <file>` reads → builds model → calls provider API → surfaces the API error via @clack/prompts (plumbing verified end-to-end).
- `pnpm cicheck` green (lint, format, typecheck, 57 unit tests, cspell, secretlint); E2E green against both `src` and the `dist` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)