### PR TITLE
chore(scan): update default LLM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ npx ghactivities --output ./activity.json --scan --provider google --scan-output
 
 The `--provider` option selects the LLM provider. The API key is resolved from the `--api-key` option, falling back to a provider-specific environment variable:
 
-| Provider (`--provider`) | Default model        | API key environment variable                       |
-| ----------------------- | -------------------- | -------------------------------------------------- |
-| `openai`                | `gpt-4o-mini`        | `OPENAI_API_KEY`                                   |
-| `google`                | `gemini-2.0-flash`   | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
-| `vertexai`              | `gemini-2.0-flash`   | `GOOGLE_VERTEX_API_KEY`                            |
-| `openrouter`            | `openai/gpt-4o-mini` | `OPENROUTER_API_KEY`                               |
+| Provider (`--provider`) | Default model           | API key environment variable                       |
+| ----------------------- | ----------------------- | -------------------------------------------------- |
+| `openai`                | `gpt-5.6-luna`          | `OPENAI_API_KEY`                                   |
+| `google`                | `gemini-3.1-flash-lite` | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
+| `vertexai`              | `gemini-3.1-flash-lite` | `GOOGLE_VERTEX_API_KEY`                            |
+| `openrouter`            | `openai/gpt-5.6-luna`   | `OPENROUTER_API_KEY`                               |
 
 For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vertex-project` / `--vertex-location` (or the `GOOGLE_VERTEX_PROJECT` / `GOOGLE_VERTEX_LOCATION` environment variables).
 

--- a/src/cli/parse-scan-args.test.ts
+++ b/src/cli/parse-scan-args.test.ts
@@ -28,7 +28,7 @@ describe("parseScanArgs", () => {
   it("defaults the provider to openai and picks its default model", () => {
     const result = parseScanArgs(["./out.json"], { OPENAI_API_KEY: "sk-env" });
     expect(result.provider).toBe("openai");
-    expect(result.model).toBe("gpt-4o-mini");
+    expect(result.model).toBe("gpt-5.6-luna");
     expect(result.apiKey).toBe("sk-env");
   });
 

--- a/src/cli/parse-scan-args.ts
+++ b/src/cli/parse-scan-args.ts
@@ -6,10 +6,10 @@ import type { ScanConfig, ScanOptions, ScanProvider } from "../types/scan.js";
 const ProviderSchema = z.enum(["openai", "google", "vertexai", "openrouter"]);
 
 const DEFAULT_MODELS: Record<ScanProvider, string> = {
-  openai: "gpt-4o-mini",
-  google: "gemini-2.0-flash",
-  vertexai: "gemini-2.0-flash",
-  openrouter: "openai/gpt-4o-mini",
+  openai: "gpt-5.6-luna",
+  google: "gemini-3.1-flash-lite",
+  vertexai: "gemini-3.1-flash-lite",
+  openrouter: "openai/gpt-5.6-luna",
 };
 
 // Provider-specific environment variables consulted, in order, when

--- a/src/services/scan.test.ts
+++ b/src/services/scan.test.ts
@@ -6,10 +6,10 @@ import { buildModel } from "./scan.js";
 
 describe("buildModel", () => {
   const cases: { provider: ScanProvider; model: string }[] = [
-    { provider: "openai", model: "gpt-4o-mini" },
-    { provider: "google", model: "gemini-2.0-flash" },
-    { provider: "vertexai", model: "gemini-2.0-flash" },
-    { provider: "openrouter", model: "openai/gpt-4o-mini" },
+    { provider: "openai", model: "gpt-5.6-luna" },
+    { provider: "google", model: "gemini-3.1-flash-lite" },
+    { provider: "vertexai", model: "gemini-3.1-flash-lite" },
+    { provider: "openrouter", model: "openai/gpt-5.6-luna" },
   ];
 
   for (const { provider, model } of cases) {


### PR DESCRIPTION
## Summary

- Update default scan models across providers:
  - `openai`: `gpt-4o-mini` -> `gpt-5.6-luna`
  - `google` / `vertexai`: `gemini-2.0-flash` -> `gemini-3.1-flash-lite`
  - `openrouter`: `openai/gpt-4o-mini` -> `openai/gpt-5.6-luna`
- Keep the README providers table in sync.
- Update co-located tests (`parse-scan-args.test.ts`, `scan.test.ts`) to match.

These are defaults applied only when `--model` is not specified; explicit `--model` behavior is unchanged.

## Test plan

- `pnpm cicheck` passes (fmt, lint, typecheck, 57 unit tests, cspell, secretlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)