### PR TITLE
fix: publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,22 +3,35 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.0.0)"
+        required: true
+        type: string
 
 jobs:
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest
 
+    # `id-token: write` lets pnpm exchange a GitHub OIDC token for a short-lived
+    # npm credential (npm trusted publishing), so no NPM_TOKEN secret is needed.
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Verify release source
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid release tag: $RELEASE_TAG"
@@ -56,11 +69,6 @@ jobs:
 
       - name: Build project
         run: pnpm run build
-
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
         run: pnpm publish --no-git-checks


### PR DESCRIPTION
## Summary

The `v1.0.0` release workflow failed at the `Publish to npm` step with:

```
[E404] 404 Not Found - PUT https://registry.npmjs.org/ghactivities - Not found
```

npm returns 404 (not 403) when the credential has no publish rights on an existing package, so the `NPM_TOKEN` secret was expired or under-scoped. `v1.0.0` was never published to npm (latest there is still `0.4.0`).

Rather than rotating the token, this switches the workflow to **npm trusted publishing** (OIDC).

## Changes

- Grant the `publish` job `id-token: write` (plus explicit `contents: read`) so pnpm can exchange a GitHub OIDC token for a short-lived npm credential. The previous run logged `Skipped OIDC: ERR_PNPM_ID_TOKEN_GITHUB_WORKFLOW_INCORRECT_PERMISSIONS` because this permission was missing.
- Remove the `Configure npm authentication` step and the `NPM_TOKEN` secret usage. A stale token in `~/.npmrc` would take precedence over the OIDC credential.
- Add a `workflow_dispatch` trigger with a `tag` input so a failed publish can be retried without deleting and recreating the GitHub release.

The existing `Verify release source` guard is unchanged and still applies to dispatch runs: it rejects malformed tags, tags that disagree with `package.json`, and commits that are not in `main` history.

## Verification

- `pnpm cicheck` passes locally (format, lint, typecheck, 57 tests, cspell, secretlint).
- The publish path itself can only be verified by running the workflow; it will be dispatched against `v1.0.0` after merge.

## Note

This requires the trusted publisher to be configured on npmjs.com for `ghactivities` with repository `dyoshikawa/ghactivities` and workflow file `.github/workflows/release.yml`. The `NPM_TOKEN` secret can be deleted once this is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)