### PR TITLE
fix: resolve pnpm via mise in devcontainer init.sh

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -11,7 +11,7 @@ sudo mkdir -p /workspace-worktrees
 sudo chown -R node:node /workspace-worktrees 2>/dev/null || true
 
 # Configure pnpm store directory for devcontainer
-pnpm config set store-dir /home/node/.pnpm-store
+mise exec -- pnpm config set store-dir /home/node/.pnpm-store
 
 # Install project dependencies
 mise exec -c "pnpm i"

--- a/cspell.json
+++ b/cspell.json
@@ -218,6 +218,7 @@
     "trivyignores",
     "aquasecurity",
     "misconfig",
-    "worktree"
+    "worktree",
+    "worktrees"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the devcontainer build warning:

```
info Run command : init.sh...
warn /home/node/bin/init.sh: line 14: pnpm: command not found
```

### Root cause
`init.sh` line 14 called `pnpm` directly, but the `pnpm` shim is only added to `PATH` when `.bashrc` runs `eval "$(mise activate bash)"`. Because `init.sh` runs as a **non-interactive** shell (via `postCreateCommand`), the `. ~/.bashrc` on line 3 returns early (the standard non-interactive guard) before reaching the mise activation, so the shim is never on `PATH`. Line 17 already worked because it goes through `mise exec`.

### Fix
Run the pnpm config command through `mise exec --`, matching the established pattern in `init.sh` (line 17) and the Dockerfile (`mise exec -- ...`).

Also adds `worktrees` to the cspell dictionary: the full `cspell --gitignore .` run skips the dot-directory `.devcontainer`, but `lint-staged` checks the staged `init.sh` explicitly and flagged the pre-existing plural `worktrees` (only `worktree` was registered).

## Test plan
- [x] `pnpm cicheck` passes
- [ ] Devcontainer rebuild no longer emits `pnpm: command not found` (verify locally via Rebuild Container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)