### PR TITLE
fix: paginate nested comment connections so threads with 100+ comments are fully scanned

### DIFF
--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -39,6 +39,7 @@ export const ISSUE_COMMENT_SEARCH_QUERY = `
       }
       nodes {
         ... on Issue {
+          id
           title
           url
           createdAt
@@ -98,6 +99,7 @@ export const DISCUSSION_COMMENT_SEARCH_QUERY = `
       }
       nodes {
         ... on Discussion {
+          id
           title
           url
           createdAt
@@ -157,6 +159,7 @@ export const PULL_REQUEST_COMMENT_SEARCH_QUERY = `
       }
       nodes {
         ... on PullRequest {
+          id
           title
           url
           createdAt
@@ -182,6 +185,34 @@ export const PULL_REQUEST_COMMENT_SEARCH_QUERY = `
     }
   }
 `;
+
+// Fetches the next pages of a comment connection for a single issue,
+// discussion, or pull request surfaced by a comment search whose first 100
+// comments did not cover the whole thread.
+const buildCommentsPageQuery = (typename: "Issue" | "Discussion" | "PullRequest"): string => `
+  query ($nodeId: ID!, $first: Int!, $after: String!) {
+    node(id: $nodeId) {
+      ... on ${typename} {
+        comments(first: $first, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            body
+            url
+            createdAt
+            author { login }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const ISSUE_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("Issue");
+export const DISCUSSION_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("Discussion");
+export const PULL_REQUEST_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("PullRequest");
 
 export const CONTRIBUTIONS_COLLECTION_QUERY = `
   query ($login: String!, $from: DateTime!, $to: DateTime!) {

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -6,9 +6,10 @@ import { GitHubService } from "./github.js";
 // can assert none of them uses a reserved variable key, and exposes a mutable
 // node list served to the issue-comment search. Declared via vi.hoisted so
 // both are available inside the (hoisted) vi.mock factory below.
-const { calls, issueCommentSearchNodes } = vi.hoisted(() => ({
+const { calls, issueCommentSearchNodes, commentPagesByCursor } = vi.hoisted(() => ({
   calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
   issueCommentSearchNodes: [] as unknown[],
+  commentPagesByCursor: new Map<string, unknown>(),
 }));
 
 // Mock @octokit/graphql with a stub that returns empty-but-valid shapes for
@@ -24,6 +25,13 @@ vi.mock("@octokit/graphql", () => {
     }
     if (query.includes("defaultBranchRef")) {
       return Promise.resolve({ repository: { defaultBranchRef: null } });
+    }
+    // Nested comment pagination: serves the comment page registered for the
+    // requested cursor. Must be checked before the viewer-id fallback because
+    // this query text also contains "id".
+    if (query.includes("node(id:")) {
+      const page = commentPagesByCursor.get(String(variables.after ?? ""));
+      return Promise.resolve({ node: page ? { comments: page } : null });
     }
     if (query.includes("search(type:")) {
       const searchQuery = String(variables.searchQuery ?? "");
@@ -50,6 +58,7 @@ vi.mock("@octokit/graphql", () => {
 beforeEach(() => {
   calls.length = 0;
   issueCommentSearchNodes.length = 0;
+  commentPagesByCursor.clear();
 });
 
 const makeService = () =>
@@ -89,6 +98,7 @@ describe("search date qualifiers", () => {
 
   it("collects an in-range comment on an issue created before the range", async () => {
     issueCommentSearchNodes.push({
+      id: "ISSUE_NODE_ID",
       title: "Old issue",
       url: "https://github.com/owner/repo/issues/1",
       createdAt: "2023-06-01T00:00:00Z",
@@ -131,6 +141,72 @@ describe("search date qualifiers", () => {
         url: "https://github.com/owner/repo/issues/1#issuecomment-1",
         repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
       },
+    ]);
+  });
+
+  it("paginates nested comments so in-range comments beyond the first page are collected", async () => {
+    issueCommentSearchNodes.push({
+      id: "ISSUE_NODE_ID",
+      title: "Busy issue",
+      url: "https://github.com/owner/repo/issues/2",
+      createdAt: "2023-06-01T00:00:00Z",
+      repository: { owner: { login: "owner" }, name: "repo", visibility: "PUBLIC" },
+      comments: {
+        pageInfo: { hasNextPage: true, endCursor: "CURSOR_PAGE_2" },
+        nodes: [
+          {
+            body: "old comment on the first page",
+            url: "https://github.com/owner/repo/issues/2#issuecomment-1",
+            createdAt: "2023-07-01T00:00:00Z",
+            author: { login: "testuser" },
+          },
+        ],
+      },
+    });
+    commentPagesByCursor.set("CURSOR_PAGE_2", {
+      pageInfo: { hasNextPage: true, endCursor: "CURSOR_PAGE_3" },
+      nodes: [
+        {
+          body: "still old, second page",
+          url: "https://github.com/owner/repo/issues/2#issuecomment-2",
+          createdAt: "2023-08-01T00:00:00Z",
+          author: { login: "testuser" },
+        },
+      ],
+    });
+    commentPagesByCursor.set("CURSOR_PAGE_3", {
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes: [
+        {
+          body: "recent comment on the last page",
+          url: "https://github.com/owner/repo/issues/2#issuecomment-3",
+          createdAt: "2024-01-10T00:00:00Z",
+          author: { login: "testuser" },
+        },
+      ],
+    });
+
+    const events = await makeService().fetchAllEvents();
+
+    const issueComments = events.filter((event) => event.type === "IssueComment");
+    expect(issueComments).toEqual([
+      {
+        type: "IssueComment",
+        createdAt: "2024-01-10T00:00:00Z",
+        issueTitle: "Busy issue",
+        issueUrl: "https://github.com/owner/repo/issues/2",
+        body: "recent comment on the last page",
+        url: "https://github.com/owner/repo/issues/2#issuecomment-3",
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+    ]);
+
+    // The follow-up pages must be requested via the node query with the
+    // surfaced item's id and the previous page's end cursor.
+    const pageCalls = calls.filter((call) => call.query.includes("node(id:"));
+    expect(pageCalls.map((call) => call.variables)).toEqual([
+      { nodeId: "ISSUE_NODE_ID", first: 100, after: "CURSOR_PAGE_2" },
+      { nodeId: "ISSUE_NODE_ID", first: 100, after: "CURSOR_PAGE_3" },
     ]);
   });
 });

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -3,6 +3,9 @@ import { graphql } from "@octokit/graphql";
 import type { Visibility } from "../types/cli.js";
 import type { GitHubEvent } from "../types/events.js";
 import type {
+  CommentNode,
+  CommentsConnection,
+  CommentsPageResponse,
   CommitHistoryResponse,
   ContributionsCollectionResponse,
   DiscussionCommentSearchResponse,
@@ -19,10 +22,13 @@ import {
   COMMIT_HISTORY_QUERY,
   CONTRIBUTIONS_COLLECTION_QUERY,
   DISCUSSION_COMMENT_SEARCH_QUERY,
+  DISCUSSION_COMMENTS_PAGE_QUERY,
   DISCUSSION_SEARCH_QUERY,
   ISSUE_COMMENT_SEARCH_QUERY,
+  ISSUE_COMMENTS_PAGE_QUERY,
   ISSUE_SEARCH_QUERY,
   PULL_REQUEST_COMMENT_SEARCH_QUERY,
+  PULL_REQUEST_COMMENTS_PAGE_QUERY,
   PULL_REQUEST_SEARCH_QUERY,
   VIEWER_ID_QUERY,
   VIEWER_QUERY,
@@ -110,6 +116,31 @@ export class GitHubService {
     return date >= this.since && date <= this.until;
   }
 
+  // The comment searches embed only the first 100 comments per item. Comments
+  // are returned oldest-first, so on long threads the recent (likely in-range)
+  // comments live in the tail pages, which must be fetched via the node query.
+  private async fetchAllComments(params: {
+    nodeId: string;
+    comments: CommentsConnection;
+    pageQuery: string;
+  }): Promise<CommentNode[]> {
+    const comments = [...params.comments.nodes];
+    let { hasNextPage, endCursor } = params.comments.pageInfo;
+
+    while (hasNextPage && endCursor) {
+      const response: CommentsPageResponse = await this.graphqlWithAuth<CommentsPageResponse>(
+        params.pageQuery,
+        { nodeId: params.nodeId, first: 100, after: endCursor },
+      );
+      const page = response.node?.comments;
+      if (!page) break;
+      comments.push(...page.nodes);
+      ({ hasNextPage, endCursor } = page.pageInfo);
+    }
+
+    return comments;
+  }
+
   private async fetchIssues(username: string): Promise<GitHubEvent[]> {
     const events: GitHubEvent[] = [];
     let cursor: string | null = null;
@@ -170,7 +201,12 @@ export class GitHubService {
       for (const node of response.search.nodes) {
         if (!this.matchesVisibility(node.repository.visibility)) continue;
 
-        for (const comment of node.comments.nodes) {
+        const comments = await this.fetchAllComments({
+          nodeId: node.id,
+          comments: node.comments,
+          pageQuery: ISSUE_COMMENTS_PAGE_QUERY,
+        });
+        for (const comment of comments) {
           if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
             events.push({
               type: "IssueComment",
@@ -257,7 +293,12 @@ export class GitHubService {
       for (const node of response.search.nodes) {
         if (!this.matchesVisibility(node.repository.visibility)) continue;
 
-        for (const comment of node.comments.nodes) {
+        const comments = await this.fetchAllComments({
+          nodeId: node.id,
+          comments: node.comments,
+          pageQuery: DISCUSSION_COMMENTS_PAGE_QUERY,
+        });
+        for (const comment of comments) {
           if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
             events.push({
               type: "DiscussionComment",
@@ -344,7 +385,12 @@ export class GitHubService {
       for (const node of response.search.nodes) {
         if (!this.matchesVisibility(node.repository.visibility)) continue;
 
-        for (const comment of node.comments.nodes) {
+        const comments = await this.fetchAllComments({
+          nodeId: node.id,
+          comments: node.comments,
+          pageQuery: PULL_REQUEST_COMMENTS_PAGE_QUERY,
+        });
+        for (const comment of comments) {
           if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
             events.push({
               type: "PullRequestComment",

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -31,15 +31,22 @@ export interface CommentNode {
   author: { login: string } | null;
 }
 
+export interface CommentsConnection {
+  pageInfo: PageInfo;
+  nodes: CommentNode[];
+}
+
+export interface CommentsPageResponse {
+  node: { comments: CommentsConnection } | null;
+}
+
 export interface IssueWithCommentsNode {
+  id: string;
   title: string;
   url: string;
   createdAt: string;
   repository: RepositoryNode;
-  comments: {
-    pageInfo: PageInfo;
-    nodes: CommentNode[];
-  };
+  comments: CommentsConnection;
 }
 
 export interface IssueCommentSearchResponse {
@@ -65,14 +72,12 @@ export interface DiscussionSearchResponse {
 }
 
 export interface DiscussionWithCommentsNode {
+  id: string;
   title: string;
   url: string;
   createdAt: string;
   repository: RepositoryNode;
-  comments: {
-    pageInfo: PageInfo;
-    nodes: CommentNode[];
-  };
+  comments: CommentsConnection;
 }
 
 export interface DiscussionCommentSearchResponse {
@@ -98,14 +103,12 @@ export interface PullRequestSearchResponse {
 }
 
 export interface PullRequestWithCommentsNode {
+  id: string;
   title: string;
   url: string;
   createdAt: string;
   repository: RepositoryNode;
-  comments: {
-    pageInfo: PageInfo;
-    nodes: CommentNode[];
-  };
+  comments: CommentsConnection;
 }
 
 export interface PullRequestCommentSearchResponse {


### PR DESCRIPTION
## Summary

Fixes #43.

The comment search queries request `comments(first: 100)` and even select `pageInfo { hasNextPage endCursor }`, but the service never followed the nested cursor. GitHub returns comments oldest-first, so on an active issue/PR/discussion with more than 100 comments, the user's *recent* comments — the ones most likely inside the collection range — were in the un-fetched tail and silently dropped.

## Changes

- The three comment search queries now also select the item `id`.
- New `buildCommentsPageQuery` factory in `github-queries.ts` producing `node(id:)`-based follow-up queries for `Issue`, `Discussion`, and `PullRequest`.
- New `fetchAllComments` helper in `GitHubService` that walks the remaining comment pages (also defensively stops if `endCursor` is null while `hasNextPage` is true, preventing a potential infinite loop).
- All three comment fetchers (`fetchIssueComments`, `fetchDiscussionComments`, `fetchPullRequestComments`) route through the helper; filtering and mapping are unchanged.
- Types: extracted `CommentsConnection`, added `CommentsPageResponse`, added `id` to the three with-comments node types.

## Tests

- New test: an in-range comment sitting on the third comment page is collected, and the follow-up `node(id:)` calls are asserted (correct node id, cursor chain).
- `pnpm cicheck` passes (format, lint, typecheck, 60 unit tests, cspell, secretlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
