### PR TITLE
fix: include INTERNAL repository visibility instead of silently excluding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vert
 ## Notes
 
 - **Commits** are collected from each repository's **default branch** only; commits on other branches are not included.
+- Repositories with `INTERNAL` visibility (organization-internal repositories on GitHub Enterprise) are treated as private: they are included with `--visibility private` and `--visibility all`, and excluded with `--visibility public`.
 - GitHub's Search API returns at most 1,000 results per query. When a query would exceed that cap, the date range is automatically split into smaller windows and searched again. If a single UTC day still exceeds the cap, the excess items are skipped and a warning is printed.
 - For issues, pull requests, and discussions, the range is matched at day granularity (the date portion of `--since`/`--until`); comments and commits are matched at full timestamp precision.
 

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -71,13 +71,14 @@ beforeEach(() => {
 const makeService = (params?: {
   since?: Date;
   until?: Date;
+  visibility?: "public" | "private" | "all";
   onWarning?: (message: string) => void;
 }) =>
   new GitHubService({
     token: "test-token",
     since: params?.since ?? new Date("2024-01-01T00:00:00Z"),
     until: params?.until ?? new Date("2024-01-15T00:00:00Z"),
-    visibility: "public",
+    visibility: params?.visibility ?? "public",
     ...(params?.onWarning ? { onWarning: params.onWarning } : {}),
   });
 
@@ -315,6 +316,50 @@ describe("search result cap handling", () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("1000");
     expect(warnings[0]).toContain("author:testuser is:issue created:2024-01-05..2024-01-05");
+  });
+});
+
+const visibilityNode = (visibility: string) => ({
+  title: `${visibility} issue`,
+  url: `https://github.com/owner/repo/issues/${visibility}`,
+  body: "",
+  createdAt: "2024-01-02T00:00:00Z",
+  repository: { owner: { login: "owner" }, name: "repo", visibility },
+});
+
+describe("repository visibility filtering", () => {
+  const setIssueSearchNodes = (nodes: unknown[]) => {
+    searchResponsesByQuery.set("author:testuser is:issue created:2024-01-01..2024-01-15", {
+      issueCount: nodes.length,
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes,
+    });
+  };
+
+  const collectIssueTitles = async (visibility: "public" | "private" | "all") => {
+    setIssueSearchNodes([
+      visibilityNode("PUBLIC"),
+      visibilityNode("PRIVATE"),
+      visibilityNode("INTERNAL"),
+    ]);
+    const events = await makeService({ visibility }).fetchAllEvents();
+    return events.filter((event) => event.type === "Issue").map((e) => e.title);
+  };
+
+  it("includes only PUBLIC repositories with --visibility public", async () => {
+    expect(await collectIssueTitles("public")).toEqual(["PUBLIC issue"]);
+  });
+
+  it("groups INTERNAL repositories with private", async () => {
+    expect(await collectIssueTitles("private")).toEqual(["PRIVATE issue", "INTERNAL issue"]);
+  });
+
+  it("includes every visibility with --visibility all", async () => {
+    expect(await collectIssueTitles("all")).toEqual([
+      "PUBLIC issue",
+      "PRIVATE issue",
+      "INTERNAL issue",
+    ]);
   });
 });
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -14,6 +14,7 @@ import type {
   IssueWithCommentsNode,
   PullRequestNode,
   PullRequestWithCommentsNode,
+  RepositoryVisibility,
   SearchResponse,
   ViewerResponse,
 } from "../types/github-api.js";
@@ -181,10 +182,12 @@ export class GitHubService {
     return nodes;
   }
 
-  private matchesVisibility(visibility: "PUBLIC" | "PRIVATE"): boolean {
+  private matchesVisibility(visibility: RepositoryVisibility): boolean {
     if (this.visibility === "all") return true;
     if (this.visibility === "public") return visibility === "PUBLIC";
-    return visibility === "PRIVATE";
+    // INTERNAL (org-internal on GitHub Enterprise) repositories are not
+    // publicly visible, so they group with private.
+    return visibility === "PRIVATE" || visibility === "INTERNAL";
   }
 
   private isWithinDateRange(dateStr: string): boolean {
@@ -423,7 +426,7 @@ export class GitHubService {
       until: this.until,
     });
 
-    const repoMap = new Map<string, "PUBLIC" | "PRIVATE">();
+    const repoMap = new Map<string, RepositoryVisibility>();
 
     for (const period of periods) {
       const response = await this.graphqlWithAuth<ContributionsCollectionResponse>(

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,3 +1,5 @@
+import type { RepositoryVisibility } from "./github-api.js";
+
 export type GitHubEvent =
   | IssueEvent
   | IssueCommentEvent
@@ -13,7 +15,7 @@ interface BaseEvent {
   repository: {
     owner: string;
     name: string;
-    visibility: "PUBLIC" | "PRIVATE";
+    visibility: RepositoryVisibility;
   };
 }
 

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -1,3 +1,7 @@
+// Mirrors GitHub's GraphQL RepositoryVisibility enum. INTERNAL is used by
+// organization-internal repositories on GitHub Enterprise.
+export type RepositoryVisibility = "PUBLIC" | "PRIVATE" | "INTERNAL";
+
 export interface PageInfo {
   hasNextPage: boolean;
   endCursor: string | null;
@@ -17,7 +21,7 @@ export interface SearchResponse<TNode> {
 export interface RepositoryNode {
   owner: { login: string };
   name: string;
-  visibility: "PUBLIC" | "PRIVATE";
+  visibility: RepositoryVisibility;
 }
 
 export interface IssueNode {
@@ -104,7 +108,7 @@ export interface CommitContributionNode {
   repository: {
     owner: { login: string };
     name: string;
-    visibility: "PUBLIC" | "PRIVATE";
+    visibility: RepositoryVisibility;
   };
   commitCount: number;
 }
@@ -116,7 +120,7 @@ export interface ContributionsCollectionResponse {
         repository: {
           owner: { login: string };
           name: string;
-          visibility: "PUBLIC" | "PRIVATE";
+          visibility: RepositoryVisibility;
         };
         contributions: {
           pageInfo: PageInfo;


### PR DESCRIPTION
## Summary

Fixes #45.

GitHub's GraphQL `RepositoryVisibility` enum has three values — `PUBLIC`, `PRIVATE`, and `INTERNAL` (organization-internal repos on GitHub Enterprise) — but the TS types declared only `"PUBLIC" | "PRIVATE"`, and `matchesVisibility` returned `false` for `INTERNAL` under both `--visibility public` and `--visibility private`. For a user in a GitHub Enterprise organization, `--visibility private` silently missed most of their work.

## Changes

- New shared `RepositoryVisibility` type (`"PUBLIC" | "PRIVATE" | "INTERNAL"`) in `src/types/github-api.ts`, used everywhere the inline union previously appeared (`github-api.ts`, `events.ts`, `github.ts`).
- `matchesVisibility` now groups `INTERNAL` with private: included by `--visibility private` and `--visibility all`, excluded by `--visibility public` (internal repos are not publicly visible).
- README Notes documents the mapping.

## Tests

- New visibility-matrix tests: PUBLIC/PRIVATE/INTERNAL nodes filtered under each of the three `--visibility` settings (3 tests).
- `pnpm cicheck` passes (format, lint, typecheck, 71 unit tests, cspell, secretlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
