### PR TITLE
fix: retry transient GitHub API failures and serialize fetchers with error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vert
 
 - **Commits** are collected from each repository's **default branch** only; commits on other branches are not included.
 - Repositories with `INTERNAL` visibility (organization-internal repositories on GitHub Enterprise) are treated as private: they are included with `--visibility private` and `--visibility all`, and excluded with `--visibility public`.
+- Event types are fetched one at a time (not concurrently) to stay within GitHub's secondary rate limits. Transient API failures — rate limits and gateway errors — are retried up to 3 times, honoring the server-suggested wait when provided and falling back to exponential backoff. If fetching still fails, the error names the event type that was being fetched.
 - GitHub's Search API returns at most 1,000 results per query. When a query would exceed that cap, the date range is automatically split into smaller windows and searched again. If a single UTC day still exceeds the cap, the excess items are skipped and a warning is printed.
 - For issues, pull requests, and discussions, the range is matched at day granularity (the date portion of `--since`/`--until`); comments and commits are matched at full timestamp precision.
 

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { GitHubService } from "./github.js";
+import { computeRetryDelayMs, GitHubService } from "./github.js";
 
 // Records every call the GitHubService makes to @octokit/graphql so the test
 // can assert none of them uses a reserved variable key, and exposes a mutable
@@ -84,7 +84,7 @@ const makeService = (params?: {
   until?: Date;
   visibility?: "public" | "private" | "all";
   onWarning?: (message: string) => void;
-  retry?: { maxAttempts?: number; baseDelayMs?: number };
+  retry?: { maxRetries?: number; baseDelayMs?: number };
 }) =>
   new GitHubService({
     token: "test-token",
@@ -427,6 +427,42 @@ describe("transient failure handling", () => {
       makeService({ onWarning: (message) => warnings.push(message) }).fetchAllEvents(),
     ).rejects.toThrow("Failed to fetch issues: Bad credentials");
     expect(warnings).toEqual([]);
+  });
+});
+
+describe("computeRetryDelayMs", () => {
+  it("honors retry-after from RequestError-shaped errors (response.headers)", () => {
+    const delay = computeRetryDelayMs({
+      error: { response: { headers: { "retry-after": "5" } } },
+      attempt: 0,
+      baseDelayMs: 1000,
+    });
+    expect(delay).toBe(5000);
+  });
+
+  it("honors top-level headers from GraphqlResponseError-shaped errors", () => {
+    const delay = computeRetryDelayMs({
+      error: { headers: { "retry-after": 7 } },
+      attempt: 0,
+      baseDelayMs: 1000,
+    });
+    expect(delay).toBe(7000);
+  });
+
+  it("waits until x-ratelimit-reset, capped at one minute", () => {
+    const resetInTwoMinutes = Math.round(Date.now() / 1000) + 120;
+    const delay = computeRetryDelayMs({
+      error: { headers: { "x-ratelimit-reset": resetInTwoMinutes } },
+      attempt: 0,
+      baseDelayMs: 1000,
+    });
+    expect(delay).toBe(60_000);
+  });
+
+  it("falls back to exponential backoff and rejects malformed header values", () => {
+    const error = { headers: { "retry-after": "soon", "x-ratelimit-reset": "-5" } };
+    expect(computeRetryDelayMs({ error, attempt: 0, baseDelayMs: 1000 })).toBe(1000);
+    expect(computeRetryDelayMs({ error, attempt: 2, baseDelayMs: 1000 })).toBe(4000);
   });
 });
 

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -6,20 +6,30 @@ import { GitHubService } from "./github.js";
 // can assert none of them uses a reserved variable key, and exposes a mutable
 // node list served to the issue-comment search. Declared via vi.hoisted so
 // both are available inside the (hoisted) vi.mock factory below.
-const { calls, issueCommentSearchNodes, commentPagesByCursor, searchResponsesByQuery } = vi.hoisted(
-  () => ({
+const { calls, issueCommentSearchNodes, commentPagesByCursor, searchResponsesByQuery, failures } =
+  vi.hoisted(() => ({
     calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
     issueCommentSearchNodes: [] as unknown[],
     commentPagesByCursor: new Map<string, unknown>(),
     searchResponsesByQuery: new Map<string, unknown>(),
-  }),
-);
+    // Failure injection: while a substring's error list is non-empty, calls
+    // whose query or searchQuery contains the substring reject with the next
+    // error from the list.
+    failures: new Map<string, unknown[]>(),
+  }));
 
 // Mock @octokit/graphql with a stub that returns empty-but-valid shapes for
 // each query the service issues, and records the (query, variables) pairs.
 vi.mock("@octokit/graphql", () => {
   const impl = (query: string, variables: Record<string, unknown> = {}) => {
     calls.push({ query, variables });
+
+    const failureKey = `${query} ${String(variables.searchQuery ?? "")}`;
+    for (const [substring, errors] of failures) {
+      if (errors.length > 0 && failureKey.includes(substring)) {
+        return Promise.reject(errors.shift());
+      }
+    }
 
     if (query.includes("contributionsCollection")) {
       return Promise.resolve({
@@ -66,6 +76,7 @@ beforeEach(() => {
   issueCommentSearchNodes.length = 0;
   commentPagesByCursor.clear();
   searchResponsesByQuery.clear();
+  failures.clear();
 });
 
 const makeService = (params?: {
@@ -73,6 +84,7 @@ const makeService = (params?: {
   until?: Date;
   visibility?: "public" | "private" | "all";
   onWarning?: (message: string) => void;
+  retry?: { maxAttempts?: number; baseDelayMs?: number };
 }) =>
   new GitHubService({
     token: "test-token",
@@ -80,6 +92,7 @@ const makeService = (params?: {
     until: params?.until ?? new Date("2024-01-15T00:00:00Z"),
     visibility: params?.visibility ?? "public",
     ...(params?.onWarning ? { onWarning: params.onWarning } : {}),
+    retry: params?.retry ?? { baseDelayMs: 1 },
   });
 
 describe("search date qualifiers", () => {
@@ -360,6 +373,60 @@ describe("repository visibility filtering", () => {
       "PRIVATE issue",
       "INTERNAL issue",
     ]);
+  });
+});
+
+const rateLimitedError = () =>
+  Object.assign(new Error("API rate limit exceeded"), {
+    errors: [{ type: "RATE_LIMITED" }],
+  });
+
+describe("transient failure handling", () => {
+  const issueSearchKey = "author:testuser is:issue";
+
+  it("retries transient errors and succeeds", async () => {
+    const warnings: string[] = [];
+    failures.set(issueSearchKey, [Object.assign(new Error("Bad gateway"), { status: 502 })]);
+    searchResponsesByQuery.set("author:testuser is:issue created:2024-01-01..2024-01-15", {
+      issueCount: 1,
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes: [issueNode("recovered")],
+    });
+
+    const events = await makeService({
+      onWarning: (message) => warnings.push(message),
+    }).fetchAllEvents();
+
+    const issueTitles = events.filter((event) => event.type === "Issue").map((e) => e.title);
+    expect(issueTitles).toEqual(["recovered"]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("retrying");
+    expect(warnings[0]).toContain("Bad gateway");
+  });
+
+  it("gives up after the retry budget and names the failing fetcher", async () => {
+    const warnings: string[] = [];
+    failures.set(issueSearchKey, [
+      rateLimitedError(),
+      rateLimitedError(),
+      rateLimitedError(),
+      rateLimitedError(),
+    ]);
+
+    await expect(
+      makeService({ onWarning: (message) => warnings.push(message) }).fetchAllEvents(),
+    ).rejects.toThrow(/Failed to fetch issues: .*rate limit/);
+    expect(warnings).toHaveLength(3);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const warnings: string[] = [];
+    failures.set(issueSearchKey, [Object.assign(new Error("Bad credentials"), { status: 401 })]);
+
+    await expect(
+      makeService({ onWarning: (message) => warnings.push(message) }).fetchAllEvents(),
+    ).rejects.toThrow("Failed to fetch issues: Bad credentials");
+    expect(warnings).toEqual([]);
   });
 });
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -26,6 +26,7 @@ import {
   splitDateRangeIntoYearPeriods,
   toUtcDayString,
 } from "../utils/date-range.js";
+import { formatError } from "../utils/error.js";
 import {
   COMMIT_HISTORY_QUERY,
   CONTRIBUTIONS_COLLECTION_QUERY,
@@ -48,10 +49,45 @@ interface GitHubServiceParams {
   until: Date;
   visibility: Visibility;
   onWarning?: (message: string) => void;
+  retry?: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+  };
 }
 
 // GitHub's Search API never returns more than 1,000 results per query.
 const SEARCH_RESULT_CAP = 1000;
+
+// Retry policy for transient GitHub API failures.
+const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 60_000;
+const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
+
+// The relevant fields of errors thrown by @octokit/graphql: RequestError
+// exposes `status` and `response.headers`; GraphqlResponseError exposes the
+// GraphQL `errors` array (rate limiting surfaces as type RATE_LIMITED).
+interface GitHubApiErrorShape {
+  status?: number;
+  message?: string;
+  response?: { headers?: Record<string, string | number | undefined> };
+  errors?: { type?: string }[];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isRetryableError(error: unknown): boolean {
+  const err = error as GitHubApiErrorShape;
+  if (err.errors?.some((graphqlError) => graphqlError.type === "RATE_LIMITED")) return true;
+  if (typeof err.status !== "number") return false;
+  if (RETRYABLE_STATUS_CODES.has(err.status)) return true;
+  // Secondary rate limits surface as 403 with a rate-limit/abuse message.
+  return err.status === 403 && /rate limit|abuse/i.test(err.message ?? "");
+}
 
 export class GitHubService {
   private readonly graphqlWithAuth: typeof graphql;
@@ -59,6 +95,8 @@ export class GitHubService {
   private readonly until: Date;
   private readonly visibility: Visibility;
   private readonly onWarning: (message: string) => void;
+  private readonly retryMaxAttempts: number;
+  private readonly retryBaseDelayMs: number;
 
   constructor(params: GitHubServiceParams) {
     this.graphqlWithAuth = graphql.defaults({
@@ -68,31 +106,77 @@ export class GitHubService {
     this.until = params.until;
     this.visibility = params.visibility;
     this.onWarning = params.onWarning ?? (() => {});
+    this.retryMaxAttempts = params.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
+    this.retryBaseDelayMs = params.retry?.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
   }
 
   async fetchAllEvents(): Promise<GitHubEvent[]> {
     const username = await this.getViewerLogin();
 
-    const results = await Promise.all([
-      this.fetchIssues(username),
-      this.fetchIssueComments(username),
-      this.fetchDiscussions(username),
-      this.fetchDiscussionComments(username),
-      this.fetchPullRequests(username),
-      this.fetchPullRequestComments(username),
-      this.fetchCommits(username),
-    ]);
+    // Fetchers run one at a time: GitHub's secondary rate-limit guidance is to
+    // avoid concurrent requests, and each fetcher already pages sequentially.
+    const fetchers: { label: string; run: () => Promise<GitHubEvent[]> }[] = [
+      { label: "issues", run: () => this.fetchIssues(username) },
+      { label: "issue comments", run: () => this.fetchIssueComments(username) },
+      { label: "discussions", run: () => this.fetchDiscussions(username) },
+      { label: "discussion comments", run: () => this.fetchDiscussionComments(username) },
+      { label: "pull requests", run: () => this.fetchPullRequests(username) },
+      { label: "pull request comments", run: () => this.fetchPullRequestComments(username) },
+      { label: "commits", run: () => this.fetchCommits(username) },
+    ];
 
-    return results.flat();
+    const events: GitHubEvent[] = [];
+    for (const fetcher of fetchers) {
+      try {
+        events.push(...(await fetcher.run()));
+      } catch (error) {
+        throw new Error(`Failed to fetch ${fetcher.label}: ${formatError(error)}`, {
+          cause: error,
+        });
+      }
+    }
+    return events;
+  }
+
+  // Executes a GraphQL request, retrying transient failures (rate limits and
+  // gateway errors) with the server-suggested delay when available, falling
+  // back to exponential backoff.
+  private async execute<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await this.graphqlWithAuth<T>(query, variables ?? {});
+      } catch (error) {
+        if (attempt >= this.retryMaxAttempts || !isRetryableError(error)) throw error;
+        const delayMs = this.retryDelayMs(error, attempt);
+        this.onWarning(
+          `GitHub API request failed (${formatError(error)}); retrying in ${String(Math.ceil(delayMs / 1000))}s (attempt ${String(attempt + 1)}/${String(this.retryMaxAttempts)}).`,
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  private retryDelayMs(error: unknown, attempt: number): number {
+    const headers = (error as GitHubApiErrorShape).response?.headers ?? {};
+    const retryAfterSeconds = Number(headers["retry-after"]);
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+      return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY_MS);
+    }
+    const resetEpochSeconds = Number(headers["x-ratelimit-reset"]);
+    if (Number.isFinite(resetEpochSeconds) && resetEpochSeconds > 0) {
+      const waitMs = resetEpochSeconds * 1000 - Date.now();
+      if (waitMs > 0) return Math.min(waitMs, MAX_RETRY_DELAY_MS);
+    }
+    return Math.min(this.retryBaseDelayMs * 2 ** attempt, MAX_RETRY_DELAY_MS);
   }
 
   private async getViewerLogin(): Promise<string> {
-    const response = await this.graphqlWithAuth<ViewerResponse>(VIEWER_QUERY);
+    const response = await this.execute<ViewerResponse>(VIEWER_QUERY);
     return response.viewer.login;
   }
 
   private async getViewerId(): Promise<string> {
-    const response = await this.graphqlWithAuth<{
+    const response = await this.execute<{
       viewer: { id: string; login: string };
     }>(VIEWER_ID_QUERY);
     return response.viewer.id;
@@ -147,10 +231,11 @@ export class GitHubService {
       window,
     });
 
-    let response: SearchResponse<TNode> = await this.graphqlWithAuth<SearchResponse<TNode>>(
-      params.query,
-      { searchQuery, first: 100, after: null },
-    );
+    let response: SearchResponse<TNode> = await this.execute<SearchResponse<TNode>>(params.query, {
+      searchQuery,
+      first: 100,
+      after: null,
+    });
 
     const totalCount = response.search.issueCount ?? response.search.discussionCount;
     if (totalCount === undefined) {
@@ -172,7 +257,7 @@ export class GitHubService {
 
     const nodes = [...response.search.nodes];
     while (response.search.pageInfo.hasNextPage && response.search.pageInfo.endCursor) {
-      response = await this.graphqlWithAuth<SearchResponse<TNode>>(params.query, {
+      response = await this.execute<SearchResponse<TNode>>(params.query, {
         searchQuery,
         first: 100,
         after: response.search.pageInfo.endCursor,
@@ -207,7 +292,7 @@ export class GitHubService {
     let { hasNextPage, endCursor } = params.comments.pageInfo;
 
     while (hasNextPage && endCursor) {
-      const response: CommentsPageResponse = await this.graphqlWithAuth<CommentsPageResponse>(
+      const response: CommentsPageResponse = await this.execute<CommentsPageResponse>(
         params.pageQuery,
         { nodeId: params.nodeId, first: 100, after: endCursor },
       );
@@ -429,7 +514,7 @@ export class GitHubService {
     const repoMap = new Map<string, RepositoryVisibility>();
 
     for (const period of periods) {
-      const response = await this.graphqlWithAuth<ContributionsCollectionResponse>(
+      const response = await this.execute<ContributionsCollectionResponse>(
         CONTRIBUTIONS_COLLECTION_QUERY,
         {
           login: username,
@@ -452,7 +537,7 @@ export class GitHubService {
 
       // eslint-disable-next-line no-constant-condition
       while (true) {
-        const response: CommitHistoryResponse = await this.graphqlWithAuth<CommitHistoryResponse>(
+        const response: CommitHistoryResponse = await this.execute<CommitHistoryResponse>(
           COMMIT_HISTORY_QUERY,
           {
             owner,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -50,7 +50,7 @@ interface GitHubServiceParams {
   visibility: Visibility;
   onWarning?: (message: string) => void;
   retry?: {
-    maxAttempts?: number;
+    maxRetries?: number;
     baseDelayMs?: number;
   };
 }
@@ -59,17 +59,19 @@ interface GitHubServiceParams {
 const SEARCH_RESULT_CAP = 1000;
 
 // Retry policy for transient GitHub API failures.
-const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 60_000;
 const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);
 
 // The relevant fields of errors thrown by @octokit/graphql: RequestError
-// exposes `status` and `response.headers`; GraphqlResponseError exposes the
-// GraphQL `errors` array (rate limiting surfaces as type RATE_LIMITED).
+// (HTTP 4xx/5xx) exposes `status` and `response.headers`, while
+// GraphqlResponseError (HTTP 200 with an errors array, e.g. RATE_LIMITED)
+// exposes the response headers as a top-level `headers` property.
 interface GitHubApiErrorShape {
   status?: number;
   message?: string;
+  headers?: Record<string, string | number | undefined>;
   response?: { headers?: Record<string, string | number | undefined> };
   errors?: { type?: string }[];
 }
@@ -81,6 +83,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 function isRetryableError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
   const err = error as GitHubApiErrorShape;
   if (err.errors?.some((graphqlError) => graphqlError.type === "RATE_LIMITED")) return true;
   if (typeof err.status !== "number") return false;
@@ -89,13 +92,33 @@ function isRetryableError(error: unknown): boolean {
   return err.status === 403 && /rate limit|abuse/i.test(err.message ?? "");
 }
 
+// Exported for direct unit testing (no real sleeps needed).
+export function computeRetryDelayMs(params: {
+  error: unknown;
+  attempt: number;
+  baseDelayMs: number;
+}): number {
+  const err = params.error as GitHubApiErrorShape;
+  const headers = err.response?.headers ?? err.headers ?? {};
+  const retryAfterSeconds = Number(headers["retry-after"]);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+    return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY_MS);
+  }
+  const resetEpochSeconds = Number(headers["x-ratelimit-reset"]);
+  if (Number.isFinite(resetEpochSeconds) && resetEpochSeconds > 0) {
+    const waitMs = resetEpochSeconds * 1000 - Date.now();
+    if (waitMs > 0) return Math.min(waitMs, MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(params.baseDelayMs * 2 ** params.attempt, MAX_RETRY_DELAY_MS);
+}
+
 export class GitHubService {
   private readonly graphqlWithAuth: typeof graphql;
   private readonly since: Date;
   private readonly until: Date;
   private readonly visibility: Visibility;
   private readonly onWarning: (message: string) => void;
-  private readonly retryMaxAttempts: number;
+  private readonly maxRetries: number;
   private readonly retryBaseDelayMs: number;
 
   constructor(params: GitHubServiceParams) {
@@ -106,12 +129,17 @@ export class GitHubService {
     this.until = params.until;
     this.visibility = params.visibility;
     this.onWarning = params.onWarning ?? (() => {});
-    this.retryMaxAttempts = params.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
+    this.maxRetries = params.retry?.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.retryBaseDelayMs = params.retry?.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
   }
 
   async fetchAllEvents(): Promise<GitHubEvent[]> {
-    const username = await this.getViewerLogin();
+    let username: string;
+    try {
+      username = await this.getViewerLogin();
+    } catch (error) {
+      throw new Error(`Failed to fetch viewer login: ${formatError(error)}`, { cause: error });
+    }
 
     // Fetchers run one at a time: GitHub's secondary rate-limit guidance is to
     // avoid concurrent requests, and each fetcher already pages sequentially.
@@ -146,28 +174,18 @@ export class GitHubService {
       try {
         return await this.graphqlWithAuth<T>(query, variables ?? {});
       } catch (error) {
-        if (attempt >= this.retryMaxAttempts || !isRetryableError(error)) throw error;
-        const delayMs = this.retryDelayMs(error, attempt);
+        if (attempt >= this.maxRetries || !isRetryableError(error)) throw error;
+        const delayMs = computeRetryDelayMs({
+          error,
+          attempt,
+          baseDelayMs: this.retryBaseDelayMs,
+        });
         this.onWarning(
-          `GitHub API request failed (${formatError(error)}); retrying in ${String(Math.ceil(delayMs / 1000))}s (attempt ${String(attempt + 1)}/${String(this.retryMaxAttempts)}).`,
+          `GitHub API request failed (${formatError(error)}); retrying in ${String(Math.ceil(delayMs / 1000))}s (retry ${String(attempt + 1)}/${String(this.maxRetries)}).`,
         );
         await sleep(delayMs);
       }
     }
-  }
-
-  private retryDelayMs(error: unknown, attempt: number): number {
-    const headers = (error as GitHubApiErrorShape).response?.headers ?? {};
-    const retryAfterSeconds = Number(headers["retry-after"]);
-    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
-      return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY_MS);
-    }
-    const resetEpochSeconds = Number(headers["x-ratelimit-reset"]);
-    if (Number.isFinite(resetEpochSeconds) && resetEpochSeconds > 0) {
-      const waitMs = resetEpochSeconds * 1000 - Date.now();
-      if (waitMs > 0) return Math.min(waitMs, MAX_RETRY_DELAY_MS);
-    }
-    return Math.min(this.retryBaseDelayMs * 2 ** attempt, MAX_RETRY_DELAY_MS);
   }
 
   private async getViewerLogin(): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes #46.

The seven fetchers ran concurrently under a single `Promise.all` with no retry: one transient failure (rate limit, 502) aborted the whole run, discarded all fetched data, and surfaced a raw octokit error with no hint of which fetcher failed. Concurrent requests also go against GitHub's secondary rate-limit guidance.

## Changes

- **Retry with backoff**: all GraphQL requests now go through a private `execute` wrapper. Retryable failures — HTTP 429/502/503/504, GraphQL `RATE_LIMITED` errors, and 403s with rate-limit/abuse messages — are retried up to 3 times (configurable via a new `retry` param). The delay honors `retry-after`, then `x-ratelimit-reset`, then falls back to exponential backoff, capped at 60 s. Each retry emits an `onWarning` message (shown via clack in the CLI).
- **Serialized fetchers**: the seven event-type fetchers run one at a time instead of under `Promise.all`, per GitHub's guidance to avoid concurrent requests.
- **Per-fetcher error context**: a failure now throws `Failed to fetch <event type>: <message>` (with `cause` preserved) instead of a bare octokit error. The run still fails as a whole — partial-output behavior was considered and deliberately not adopted, keeping the CLI's all-or-nothing contract.
- README Notes documents the retry/serialization behavior.

## Tests

- New failure-injection harness in the graphql mock (substring-keyed error queues).
- Tests: transient 502 retried then succeeds (with warning); retry budget exhausted → error names the failing fetcher; non-retryable 401 fails immediately without retry.
- `pnpm cicheck` passes (format, lint, typecheck, 74 unit tests, cspell, secretlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
