### PR TITLE
feat: collect pull request review comments as PullRequestReviewComment events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ghactivities
 
-A CLI tool that collects your GitHub activity — issues, issue comments, discussions, discussion comments, pull requests, pull request comments, and commits — and writes them to a JSON file.
+A CLI tool that collects your GitHub activity — issues, issue comments, discussions, discussion comments, pull requests, pull request comments, pull request review comments, and commits — and writes them to a JSON file.
 
 ## Features
 
@@ -11,7 +11,8 @@ Fetches the following events authored by you within a date range and outputs the
 - **Discussion** — discussions you created
 - **DiscussionComment** — comments you left on discussions
 - **PullRequest** — pull requests you opened
-- **PullRequestComment** — comments you left on pull requests
+- **PullRequestComment** — conversation comments you left on pull requests
+- **PullRequestReviewComment** — review feedback you left on pull requests (review summary bodies and inline review comments on the diff)
 - **Commit** — commits you authored (on each repository's default branch)
 
 It can also **scan** the collected JSON with an LLM to produce a Markdown summary report — see [Scanning activity with an LLM](#scanning-activity-with-an-llm).

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vert
 - Repositories with `INTERNAL` visibility (organization-internal repositories on GitHub Enterprise) are treated as private: they are included with `--visibility private` and `--visibility all`, and excluded with `--visibility public`.
 - Event types are fetched one at a time (not concurrently) to stay within GitHub's secondary rate limits. Transient API failures — rate limits and gateway errors — are retried up to 3 times, honoring the server-suggested wait when provided and falling back to exponential backoff. If fetching still fails, the error names the event type that was being fetched.
 - GitHub's Search API returns at most 1,000 results per query. When a query would exceed that cap, the date range is automatically split into smaller windows and searched again. If a single UTC day still exceeds the cap, the excess items are skipped and a warning is printed.
-- For issues, pull requests, and discussions, the range is matched at day granularity (the date portion of `--since`/`--until`); comments and commits are matched at full timestamp precision.
+- For issues, pull requests, and discussions, the range is matched at day granularity (the date portion of `--since`/`--until`); comments (including review summary bodies and inline review comments) and commits are matched at full timestamp precision. Review events use the review's submission time.
 
 ## License
 

--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -195,7 +195,9 @@ export const PULL_REQUEST_COMMENT_SEARCH_QUERY = `
 // Fetches the next pages of a comment connection for a single issue,
 // discussion, or pull request surfaced by a comment search whose first 100
 // comments did not cover the whole thread.
-const buildCommentsPageQuery = (typename: "Issue" | "Discussion" | "PullRequest"): string => `
+const buildCommentsPageQuery = (
+  typename: "Issue" | "Discussion" | "PullRequest" | "PullRequestReview",
+): string => `
   query ($nodeId: ID!, $first: Int!, $after: String!) {
     node(id: $nodeId) {
       ... on ${typename} {
@@ -219,6 +221,82 @@ const buildCommentsPageQuery = (typename: "Issue" | "Discussion" | "PullRequest"
 export const ISSUE_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("Issue");
 export const DISCUSSION_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("Discussion");
 export const PULL_REQUEST_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("PullRequest");
+export const REVIEW_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("PullRequestReview");
+
+// Reviews carry both a summary body and the inline review comments left on the
+// diff. Nested `first` sizes stay small to respect GitHub's node limit; the
+// tails are fetched through the page queries below.
+const REVIEW_FIELDS = `
+  id
+  body
+  url
+  createdAt
+  author { login }
+  comments(first: 25) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      body
+      url
+      createdAt
+      author { login }
+    }
+  }
+`;
+
+export const PULL_REQUEST_REVIEW_SEARCH_QUERY = `
+  query ($searchQuery: String!, $first: Int!, $after: String) {
+    search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
+      issueCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        ... on PullRequest {
+          id
+          title
+          url
+          createdAt
+          repository {
+            owner { login }
+            name
+            visibility
+          }
+          reviews(first: 25) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+${REVIEW_FIELDS}
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const REVIEWS_PAGE_QUERY = `
+  query ($nodeId: ID!, $first: Int!, $after: String!) {
+    node(id: $nodeId) {
+      ... on PullRequest {
+        reviews(first: $first, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+${REVIEW_FIELDS}
+          }
+        }
+      }
+    }
+  }
+`;
 
 export const CONTRIBUTIONS_COLLECTION_QUERY = `
   query ($login: String!, $from: DateTime!, $to: DateTime!) {

--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -225,12 +225,18 @@ export const REVIEW_COMMENTS_PAGE_QUERY = buildCommentsPageQuery("PullRequestRev
 
 // Reviews carry both a summary body and the inline review comments left on the
 // diff. Nested `first` sizes stay small to respect GitHub's node limit; the
-// tails are fetched through the page queries below.
+// tails are fetched through the page queries below. The states filter excludes
+// PENDING so the viewer's draft reviews that are not yet submitted never leak
+// into the export, and the author argument skips other users' reviews
+// server-side.
+const REVIEW_STATES = "[COMMENTED, APPROVED, CHANGES_REQUESTED, DISMISSED]";
+
 const REVIEW_FIELDS = `
   id
   body
   url
   createdAt
+  submittedAt
   author { login }
   comments(first: 25) {
     pageInfo {
@@ -247,7 +253,7 @@ const REVIEW_FIELDS = `
 `;
 
 export const PULL_REQUEST_REVIEW_SEARCH_QUERY = `
-  query ($searchQuery: String!, $first: Int!, $after: String) {
+  query ($searchQuery: String!, $first: Int!, $after: String, $reviewAuthor: String!) {
     search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
       issueCount
       pageInfo {
@@ -265,7 +271,7 @@ export const PULL_REQUEST_REVIEW_SEARCH_QUERY = `
             name
             visibility
           }
-          reviews(first: 25) {
+          reviews(first: 25, states: ${REVIEW_STATES}, author: $reviewAuthor) {
             pageInfo {
               hasNextPage
               endCursor
@@ -281,10 +287,10 @@ ${REVIEW_FIELDS}
 `;
 
 export const REVIEWS_PAGE_QUERY = `
-  query ($nodeId: ID!, $first: Int!, $after: String!) {
+  query ($nodeId: ID!, $first: Int!, $after: String!, $reviewAuthor: String!) {
     node(id: $nodeId) {
       ... on PullRequest {
-        reviews(first: $first, after: $after) {
+        reviews(first: $first, after: $after, states: ${REVIEW_STATES}, author: $reviewAuthor) {
           pageInfo {
             hasNextPage
             endCursor

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -425,7 +425,10 @@ describe("pull request review comments", () => {
             id: "REVIEW_1",
             body: "review summary in range",
             url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+            // Drafted at 00:00, submitted at 02:00: the event must use the
+            // submission time.
             createdAt: "2024-01-05T00:00:00Z",
+            submittedAt: "2024-01-05T02:00:00Z",
             author: { login: "testuser" },
             comments: {
               pageInfo: { hasNextPage: false, endCursor: null },
@@ -460,7 +463,12 @@ describe("pull request review comments", () => {
             url: "https://github.com/owner/repo/pull/7#pullrequestreview-3",
             createdAt: "2024-01-07T00:00:00Z",
             author: { login: "someone" },
-            comments: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            // A truthy cursor here proves the skipped review's comments are
+            // never paged.
+            comments: {
+              pageInfo: { hasNextPage: true, endCursor: "SKIPPED_REVIEW_CURSOR" },
+              nodes: [],
+            },
           },
         ],
       }),
@@ -472,7 +480,7 @@ describe("pull request review comments", () => {
     expect(reviewComments).toEqual([
       {
         type: "PullRequestReviewComment",
-        createdAt: "2024-01-05T00:00:00Z",
+        createdAt: "2024-01-05T02:00:00Z",
         prTitle: "Reviewed PR",
         prUrl: "https://github.com/owner/repo/pull/7",
         body: "review summary in range",
@@ -488,6 +496,55 @@ describe("pull request review comments", () => {
         url: "https://github.com/owner/repo/pull/7#discussion_r1",
         repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
       },
+    ]);
+
+    // The skipped other-author review must never have its comments paged.
+    const skippedPageCalls = calls.filter(
+      (call) => call.variables.after === "SKIPPED_REVIEW_CURSOR",
+    );
+    expect(skippedPageCalls).toEqual([]);
+  });
+
+  it("paginates a review's inline comment tail", async () => {
+    reviewSearchNodes.push(
+      reviewedPrNode({
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            id: "REVIEW_1",
+            body: "",
+            url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+            createdAt: "2024-01-05T00:00:00Z",
+            submittedAt: "2024-01-05T00:00:00Z",
+            author: { login: "testuser" },
+            comments: {
+              pageInfo: { hasNextPage: true, endCursor: "REVIEW_COMMENT_CURSOR_2" },
+              nodes: [],
+            },
+          },
+        ],
+      }),
+    );
+    commentPagesByCursor.set("REVIEW_COMMENT_CURSOR_2", {
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes: [
+        {
+          body: "inline comment on the second page",
+          url: "https://github.com/owner/repo/pull/7#discussion_r9",
+          createdAt: "2024-01-09T00:00:00Z",
+          author: { login: "testuser" },
+        },
+      ],
+    });
+
+    const events = await makeService().fetchAllEvents();
+
+    const reviewComments = events.filter((event) => event.type === "PullRequestReviewComment");
+    expect(reviewComments.map((e) => e.body)).toEqual(["inline comment on the second page"]);
+
+    const pageCalls = calls.filter((call) => call.variables.after === "REVIEW_COMMENT_CURSOR_2");
+    expect(pageCalls.map((call) => call.variables)).toEqual([
+      { nodeId: "REVIEW_1", first: 100, after: "REVIEW_COMMENT_CURSOR_2" },
     ]);
   });
 
@@ -521,7 +578,7 @@ describe("pull request review comments", () => {
       (call) => call.query.includes("node(id:") && call.query.includes("reviews(first:"),
     );
     expect(reviewPageCalls.map((call) => call.variables)).toEqual([
-      { nodeId: "PR_NODE_ID", first: 25, after: "REVIEW_CURSOR_2" },
+      { nodeId: "PR_NODE_ID", first: 25, after: "REVIEW_CURSOR_2", reviewAuthor: "testuser" },
     ]);
   });
 });

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -6,30 +6,72 @@ import { computeRetryDelayMs, GitHubService } from "./github.js";
 // can assert none of them uses a reserved variable key, and exposes a mutable
 // node list served to the issue-comment search. Declared via vi.hoisted so
 // both are available inside the (hoisted) vi.mock factory below.
-const { calls, issueCommentSearchNodes, commentPagesByCursor, searchResponsesByQuery, failures } =
-  vi.hoisted(() => ({
-    calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
-    issueCommentSearchNodes: [] as unknown[],
-    commentPagesByCursor: new Map<string, unknown>(),
-    searchResponsesByQuery: new Map<string, unknown>(),
-    // Failure injection: while a substring's error list is non-empty, calls
-    // whose query or searchQuery contains the substring reject with the next
-    // error from the list.
-    failures: new Map<string, unknown[]>(),
-  }));
+const {
+  calls,
+  issueCommentSearchNodes,
+  reviewSearchNodes,
+  commentPagesByCursor,
+  reviewPagesByCursor,
+  searchResponsesByQuery,
+  failures,
+} = vi.hoisted(() => ({
+  calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
+  issueCommentSearchNodes: [] as unknown[],
+  reviewSearchNodes: [] as unknown[],
+  commentPagesByCursor: new Map<string, unknown>(),
+  reviewPagesByCursor: new Map<string, unknown>(),
+  searchResponsesByQuery: new Map<string, unknown>(),
+  // Failure injection: while a substring's error list is non-empty, calls
+  // whose query or searchQuery contains the substring reject with the next
+  // error from the list.
+  failures: new Map<string, unknown[]>(),
+}));
 
 // Mock @octokit/graphql with a stub that returns empty-but-valid shapes for
 // each query the service issues, and records the (query, variables) pairs.
 vi.mock("@octokit/graphql", () => {
-  const impl = (query: string, variables: Record<string, unknown> = {}) => {
-    calls.push({ query, variables });
-
+  const findInjectedFailure = (query: string, variables: Record<string, unknown>) => {
     const failureKey = `${query} ${String(variables.searchQuery ?? "")}`;
     for (const [substring, errors] of failures) {
       if (errors.length > 0 && failureKey.includes(substring)) {
-        return Promise.reject(errors.shift());
+        return errors.shift();
       }
     }
+    return undefined;
+  };
+
+  // Nested pagination: serves the review or comment page registered for the
+  // requested cursor.
+  const handleNodePage = (query: string, variables: Record<string, unknown>) => {
+    if (query.includes("reviews(first:")) {
+      const page = reviewPagesByCursor.get(String(variables.after ?? ""));
+      return { node: page ? { reviews: page } : null };
+    }
+    const page = commentPagesByCursor.get(String(variables.after ?? ""));
+    return { node: page ? { comments: page } : null };
+  };
+
+  const handleSearch = (variables: Record<string, unknown>) => {
+    const searchQuery = String(variables.searchQuery ?? "");
+    const preset = searchResponsesByQuery.get(searchQuery);
+    if (preset) return { search: preset };
+    let nodes: unknown[] = [];
+    if (searchQuery.includes("commenter:") && searchQuery.includes("is:issue")) {
+      nodes = issueCommentSearchNodes;
+    }
+    if (searchQuery.includes("reviewed-by:")) {
+      nodes = reviewSearchNodes;
+    }
+    return {
+      search: { issueCount: 0, pageInfo: { hasNextPage: false, endCursor: null }, nodes },
+    };
+  };
+
+  const impl = (query: string, variables: Record<string, unknown> = {}) => {
+    calls.push({ query, variables });
+
+    const failure = findInjectedFailure(query, variables);
+    if (failure !== undefined) return Promise.reject(failure);
 
     if (query.includes("contributionsCollection")) {
       return Promise.resolve({
@@ -39,26 +81,12 @@ vi.mock("@octokit/graphql", () => {
     if (query.includes("defaultBranchRef")) {
       return Promise.resolve({ repository: { defaultBranchRef: null } });
     }
-    // Nested comment pagination: serves the comment page registered for the
-    // requested cursor. Must be checked before the viewer-id fallback because
-    // this query text also contains "id".
+    // Must come before the viewer-id fallback: these query texts contain "id".
     if (query.includes("node(id:")) {
-      const page = commentPagesByCursor.get(String(variables.after ?? ""));
-      return Promise.resolve({ node: page ? { comments: page } : null });
+      return Promise.resolve(handleNodePage(query, variables));
     }
     if (query.includes("search(type:")) {
-      const searchQuery = String(variables.searchQuery ?? "");
-      const preset = searchResponsesByQuery.get(searchQuery);
-      if (preset) return Promise.resolve({ search: preset });
-      const isIssueCommentSearch =
-        searchQuery.includes("commenter:") && searchQuery.includes("is:issue");
-      return Promise.resolve({
-        search: {
-          issueCount: 0,
-          pageInfo: { hasNextPage: false, endCursor: null },
-          nodes: isIssueCommentSearch ? issueCommentSearchNodes : [],
-        },
-      });
+      return Promise.resolve(handleSearch(variables));
     }
     // The only remaining queries are the two viewer lookups; the id variant is
     // the one that also selects the `id` field.
@@ -74,7 +102,9 @@ vi.mock("@octokit/graphql", () => {
 beforeEach(() => {
   calls.length = 0;
   issueCommentSearchNodes.length = 0;
+  reviewSearchNodes.length = 0;
   commentPagesByCursor.clear();
+  reviewPagesByCursor.clear();
   searchResponsesByQuery.clear();
   failures.clear();
 });
@@ -372,6 +402,126 @@ describe("repository visibility filtering", () => {
       "PUBLIC issue",
       "PRIVATE issue",
       "INTERNAL issue",
+    ]);
+  });
+});
+
+const reviewedPrNode = (reviews: unknown) => ({
+  id: "PR_NODE_ID",
+  title: "Reviewed PR",
+  url: "https://github.com/owner/repo/pull/7",
+  createdAt: "2023-06-01T00:00:00Z",
+  repository: { owner: { login: "owner" }, name: "repo", visibility: "PUBLIC" },
+  reviews,
+});
+
+describe("pull request review comments", () => {
+  it("collects in-range review bodies and inline comments authored by the viewer", async () => {
+    reviewSearchNodes.push(
+      reviewedPrNode({
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            id: "REVIEW_1",
+            body: "review summary in range",
+            url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+            createdAt: "2024-01-05T00:00:00Z",
+            author: { login: "testuser" },
+            comments: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  body: "inline comment in range",
+                  url: "https://github.com/owner/repo/pull/7#discussion_r1",
+                  createdAt: "2024-01-05T01:00:00Z",
+                  author: { login: "testuser" },
+                },
+                {
+                  body: "inline comment out of range",
+                  url: "https://github.com/owner/repo/pull/7#discussion_r2",
+                  createdAt: "2023-11-01T00:00:00Z",
+                  author: { login: "testuser" },
+                },
+              ],
+            },
+          },
+          {
+            id: "REVIEW_2",
+            // Empty body (e.g. a plain approval) must not produce an event.
+            body: "",
+            url: "https://github.com/owner/repo/pull/7#pullrequestreview-2",
+            createdAt: "2024-01-06T00:00:00Z",
+            author: { login: "testuser" },
+            comments: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          },
+          {
+            id: "REVIEW_3",
+            body: "someone else's review in range",
+            url: "https://github.com/owner/repo/pull/7#pullrequestreview-3",
+            createdAt: "2024-01-07T00:00:00Z",
+            author: { login: "someone" },
+            comments: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+          },
+        ],
+      }),
+    );
+
+    const events = await makeService().fetchAllEvents();
+
+    const reviewComments = events.filter((event) => event.type === "PullRequestReviewComment");
+    expect(reviewComments).toEqual([
+      {
+        type: "PullRequestReviewComment",
+        createdAt: "2024-01-05T00:00:00Z",
+        prTitle: "Reviewed PR",
+        prUrl: "https://github.com/owner/repo/pull/7",
+        body: "review summary in range",
+        url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+      {
+        type: "PullRequestReviewComment",
+        createdAt: "2024-01-05T01:00:00Z",
+        prTitle: "Reviewed PR",
+        prUrl: "https://github.com/owner/repo/pull/7",
+        body: "inline comment in range",
+        url: "https://github.com/owner/repo/pull/7#discussion_r1",
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+    ]);
+  });
+
+  it("paginates the reviews connection", async () => {
+    reviewSearchNodes.push(
+      reviewedPrNode({
+        pageInfo: { hasNextPage: true, endCursor: "REVIEW_CURSOR_2" },
+        nodes: [],
+      }),
+    );
+    reviewPagesByCursor.set("REVIEW_CURSOR_2", {
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes: [
+        {
+          id: "REVIEW_PAGE_2",
+          body: "review on the second page",
+          url: "https://github.com/owner/repo/pull/7#pullrequestreview-9",
+          createdAt: "2024-01-08T00:00:00Z",
+          author: { login: "testuser" },
+          comments: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+        },
+      ],
+    });
+
+    const events = await makeService().fetchAllEvents();
+
+    const reviewComments = events.filter((event) => event.type === "PullRequestReviewComment");
+    expect(reviewComments.map((e) => e.body)).toEqual(["review on the second page"]);
+
+    const reviewPageCalls = calls.filter(
+      (call) => call.query.includes("node(id:") && call.query.includes("reviews(first:"),
+    );
+    expect(reviewPageCalls.map((call) => call.variables)).toEqual([
+      { nodeId: "PR_NODE_ID", first: 25, after: "REVIEW_CURSOR_2" },
     ]);
   });
 });

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -252,6 +252,7 @@ export class GitHubService {
     qualifiers: string;
     dateField: "created" | "updated";
     window?: DateRange;
+    extraVariables?: Record<string, unknown>;
   }): Promise<TNode[]> {
     const window = params.window ?? this.initialSearchWindow(params.dateField);
     const searchQuery = this.buildWindowedSearchQuery({
@@ -261,6 +262,7 @@ export class GitHubService {
     });
 
     let response: SearchResponse<TNode> = await this.execute<SearchResponse<TNode>>(params.query, {
+      ...params.extraVariables,
       searchQuery,
       first: 100,
       after: null,
@@ -287,6 +289,7 @@ export class GitHubService {
     const nodes = [...response.search.nodes];
     while (response.search.pageInfo.hasNextPage && response.search.pageInfo.endCursor) {
       response = await this.execute<SearchResponse<TNode>>(params.query, {
+        ...params.extraVariables,
         searchQuery,
         first: 100,
         after: response.search.pageInfo.endCursor,
@@ -536,6 +539,7 @@ export class GitHubService {
   private async fetchAllReviews(params: {
     nodeId: string;
     reviews: ReviewsConnection;
+    reviewAuthor: string;
   }): Promise<ReviewNode[]> {
     const reviews = [...params.reviews.nodes];
     let { hasNextPage, endCursor } = params.reviews.pageInfo;
@@ -543,7 +547,7 @@ export class GitHubService {
     while (hasNextPage && endCursor) {
       const response: ReviewsPageResponse = await this.execute<ReviewsPageResponse>(
         REVIEWS_PAGE_QUERY,
-        { nodeId: params.nodeId, first: 25, after: endCursor },
+        { nodeId: params.nodeId, first: 25, after: endCursor, reviewAuthor: params.reviewAuthor },
       );
       const page = response.node?.reviews;
       if (!page) break;
@@ -563,6 +567,7 @@ export class GitHubService {
       query: PULL_REQUEST_REVIEW_SEARCH_QUERY,
       qualifiers: `reviewed-by:${username} is:pr`,
       dateField: "updated",
+      extraVariables: { reviewAuthor: username },
     });
 
     const events: GitHubEvent[] = [];
@@ -575,16 +580,24 @@ export class GitHubService {
         visibility: node.repository.visibility,
       };
 
-      const reviews = await this.fetchAllReviews({ nodeId: node.id, reviews: node.reviews });
+      const reviews = await this.fetchAllReviews({
+        nodeId: node.id,
+        reviews: node.reviews,
+        reviewAuthor: username,
+      });
       for (const review of reviews) {
-        // A review's inline comments share the review's author, so other
-        // users' reviews can be skipped without paging their comments.
+        // The query already filters by author server-side; this guard (and the
+        // per-comment one below) keeps the trust in our own filtering. Inline
+        // comments share the review's author, so other users' reviews can be
+        // skipped without paging their comments.
         if (review.author?.login !== username) continue;
 
-        if (review.body !== "" && this.isWithinDateRange(review.createdAt)) {
+        // A review drafted earlier counts from its submission time.
+        const reviewTimestamp = review.submittedAt ?? review.createdAt;
+        if (review.body !== "" && this.isWithinDateRange(reviewTimestamp)) {
           events.push({
             type: "PullRequestReviewComment",
-            createdAt: review.createdAt,
+            createdAt: reviewTimestamp,
             prTitle: node.title,
             prUrl: node.url,
             body: review.body,

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -14,7 +14,11 @@ import type {
   IssueWithCommentsNode,
   PullRequestNode,
   PullRequestWithCommentsNode,
+  PullRequestWithReviewsNode,
   RepositoryVisibility,
+  ReviewNode,
+  ReviewsConnection,
+  ReviewsPageResponse,
   SearchResponse,
   ViewerResponse,
 } from "../types/github-api.js";
@@ -38,7 +42,10 @@ import {
   ISSUE_SEARCH_QUERY,
   PULL_REQUEST_COMMENT_SEARCH_QUERY,
   PULL_REQUEST_COMMENTS_PAGE_QUERY,
+  PULL_REQUEST_REVIEW_SEARCH_QUERY,
   PULL_REQUEST_SEARCH_QUERY,
+  REVIEW_COMMENTS_PAGE_QUERY,
+  REVIEWS_PAGE_QUERY,
   VIEWER_ID_QUERY,
   VIEWER_QUERY,
 } from "./github-queries.js";
@@ -150,6 +157,10 @@ export class GitHubService {
       { label: "discussion comments", run: () => this.fetchDiscussionComments(username) },
       { label: "pull requests", run: () => this.fetchPullRequests(username) },
       { label: "pull request comments", run: () => this.fetchPullRequestComments(username) },
+      {
+        label: "pull request review comments",
+        run: () => this.fetchPullRequestReviewComments(username),
+      },
       { label: "commits", run: () => this.fetchCommits(username) },
     ];
 
@@ -514,6 +525,91 @@ export class GitHubService {
               visibility: node.repository.visibility,
             },
           });
+        }
+      }
+    }
+
+    return events;
+  }
+
+  // Mirrors fetchAllComments for the reviews connection of a pull request.
+  private async fetchAllReviews(params: {
+    nodeId: string;
+    reviews: ReviewsConnection;
+  }): Promise<ReviewNode[]> {
+    const reviews = [...params.reviews.nodes];
+    let { hasNextPage, endCursor } = params.reviews.pageInfo;
+
+    while (hasNextPage && endCursor) {
+      const response: ReviewsPageResponse = await this.execute<ReviewsPageResponse>(
+        REVIEWS_PAGE_QUERY,
+        { nodeId: params.nodeId, first: 25, after: endCursor },
+      );
+      const page = response.node?.reviews;
+      if (!page) break;
+      reviews.push(...page.nodes);
+      ({ hasNextPage, endCursor } = page.pageInfo);
+    }
+
+    return reviews;
+  }
+
+  // Collects review feedback the user left on pull requests: review summary
+  // bodies (when non-empty) and inline review comments on the diff. Neither is
+  // part of the conversation `comments` connection, so the commenter: search
+  // never surfaces them; PRs are found via reviewed-by: instead.
+  private async fetchPullRequestReviewComments(username: string): Promise<GitHubEvent[]> {
+    const nodes = await this.searchAllNodes<PullRequestWithReviewsNode>({
+      query: PULL_REQUEST_REVIEW_SEARCH_QUERY,
+      qualifiers: `reviewed-by:${username} is:pr`,
+      dateField: "updated",
+    });
+
+    const events: GitHubEvent[] = [];
+    for (const node of nodes) {
+      if (!this.matchesVisibility(node.repository.visibility)) continue;
+
+      const repository = {
+        owner: node.repository.owner.login,
+        name: node.repository.name,
+        visibility: node.repository.visibility,
+      };
+
+      const reviews = await this.fetchAllReviews({ nodeId: node.id, reviews: node.reviews });
+      for (const review of reviews) {
+        // A review's inline comments share the review's author, so other
+        // users' reviews can be skipped without paging their comments.
+        if (review.author?.login !== username) continue;
+
+        if (review.body !== "" && this.isWithinDateRange(review.createdAt)) {
+          events.push({
+            type: "PullRequestReviewComment",
+            createdAt: review.createdAt,
+            prTitle: node.title,
+            prUrl: node.url,
+            body: review.body,
+            url: review.url,
+            repository,
+          });
+        }
+
+        const comments = await this.fetchAllComments({
+          nodeId: review.id,
+          comments: review.comments,
+          pageQuery: REVIEW_COMMENTS_PAGE_QUERY,
+        });
+        for (const comment of comments) {
+          if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
+            events.push({
+              type: "PullRequestReviewComment",
+              createdAt: comment.createdAt,
+              prTitle: node.title,
+              prUrl: node.url,
+              body: comment.body,
+              url: comment.url,
+              repository,
+            });
+          }
         }
       }
     }

--- a/src/services/scan.ts
+++ b/src/services/scan.ts
@@ -22,7 +22,8 @@ export const MAX_SCAN_INPUT_TOKENS: Record<ScanConfig["provider"], number> = {
 
 const SYSTEM_PROMPT = `You are an assistant that reviews a developer's GitHub activity.
 The user provides a JSON export of their activity (issues, issue comments, discussions,
-discussion comments, pull requests, pull request comments, and commits).
+discussion comments, pull requests, pull request comments, pull request review comments,
+and commits).
 Analyze it and produce a concise report in Markdown that includes:
 - A short overall summary of what the developer worked on.
 - The main themes or projects, grouped by repository when useful.

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,6 +7,7 @@ export type GitHubEvent =
   | DiscussionCommentEvent
   | PullRequestEvent
   | PullRequestCommentEvent
+  | PullRequestReviewCommentEvent
   | CommitEvent;
 
 interface BaseEvent {
@@ -58,6 +59,14 @@ export interface PullRequestEvent extends BaseEvent {
 
 export interface PullRequestCommentEvent extends BaseEvent {
   type: "PullRequestComment";
+  prTitle: string;
+  prUrl: string;
+  body: string;
+  url: string;
+}
+
+export interface PullRequestReviewCommentEvent extends BaseEvent {
+  type: "PullRequestReviewComment";
   prTitle: string;
   prUrl: string;
   body: string;

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -101,6 +101,33 @@ export interface PullRequestWithCommentsNode {
   comments: CommentsConnection;
 }
 
+export interface ReviewNode {
+  id: string;
+  body: string;
+  url: string;
+  createdAt: string;
+  author: { login: string } | null;
+  comments: CommentsConnection;
+}
+
+export interface ReviewsConnection {
+  pageInfo: PageInfo;
+  nodes: ReviewNode[];
+}
+
+export interface ReviewsPageResponse {
+  node: { reviews: ReviewsConnection } | null;
+}
+
+export interface PullRequestWithReviewsNode {
+  id: string;
+  title: string;
+  url: string;
+  createdAt: string;
+  repository: RepositoryNode;
+  reviews: ReviewsConnection;
+}
+
 export type PullRequestCommentSearchResponse = SearchResponse<PullRequestWithCommentsNode>;
 
 export interface CommitContributionNode {

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -106,6 +106,8 @@ export interface ReviewNode {
   body: string;
   url: string;
   createdAt: string;
+  /** Null while a review is a pending draft; set once it is submitted. */
+  submittedAt: string | null;
   author: { login: string } | null;
   comments: CommentsConnection;
 }


### PR DESCRIPTION
## Summary

Fixes #48.

`PullRequestComment` reads only the PR conversation `comments` connection, so review feedback — review summary bodies and inline review comments on the diff — was never collected, despite the README's "comments you left on pull requests". A user whose PR feedback is mostly code review saw almost none of it in the output.

## Changes

- **New event type `PullRequestReviewComment`** (same shape as `PullRequestComment`: `prTitle`, `prUrl`, `body`, `url`). Emitted for:
  - review summary bodies authored by the viewer, when non-empty (plain approvals with no text produce no event), and
  - inline review comments authored by the viewer,
  both filtered by `isWithinDateRange` at full timestamp precision.
- **New fetcher** searching `reviewed-by:<user> is:pr` with the same `updated:` window as the other commenter-style searches (a review bumps the PR's updated date), running through the shared `searchAllNodes` cap-splitting machinery.
- **Pagination**: the `reviews` connection is paginated via a new `REVIEWS_PAGE_QUERY` (`fetchAllReviews`, mirroring `fetchAllComments`); each review's inline-comment tail reuses `fetchAllComments` with a `PullRequestReview`-fragment page query. Other users' reviews are skipped before paging their comments (inline comments share the review's author).
- README: intro, Features list, and the scan system prompt now mention review comments.

## Tests

- Behavior test: in-range review body + in-range inline comment are collected; out-of-range comments, empty bodies (plain approvals), and other authors' reviews are excluded.
- Pagination test: a second reviews page is fetched via `node(id:)` with the correct cursor and its events collected.
- `pnpm cicheck` passes (format, lint, typecheck, 83 unit tests, cspell, secretlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
