### PR TITLE
feat: add --user option to collect a specified user's activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A CLI tool that collects your GitHub activity — issues, issue comments, discus
 
 ## Features
 
-Fetches the following events authored by you within a date range and outputs them as JSON:
+Fetches the following events authored by you — or by any user given with `--user` — within a date range and outputs them as JSON:
 
 - **Issue** — issues you opened
 - **IssueComment** — comments you left on issues
@@ -47,6 +47,7 @@ To include private repositories (`--visibility private` or `--visibility all`), 
 | Option              | Description                                                                                                                                                                                | Default                                  |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
 | `--github-token`    | GitHub access token.                                                                                                                                                                       | `GITHUB_TOKEN` env, then `gh auth token` |
+| `--user`            | GitHub username whose activity is collected instead of the authenticated user's. A token is still required for API access.                                                                 | the authenticated user                   |
 | `--output`          | Output file path.                                                                                                                                                                          | `./ghactivities.json`                    |
 | `--since`           | Start of the range, in ISO 8601 format. Must not be later than `--until`.                                                                                                                  | 2 weeks ago                              |
 | `--until`           | End of the range, in ISO 8601 format.                                                                                                                                                      | now                                      |
@@ -93,6 +94,9 @@ When both `--max-length-size` and `--max-tokens` are given, a file is split as s
 ```bash
 # Collect the last two weeks of public activity into ./ghactivities.json
 npx ghactivities
+
+# Collect another user's public activity
+npx ghactivities --user octocat
 
 # Collect a specific range, including private repositories
 npx ghactivities \
@@ -163,6 +167,7 @@ For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vert
 ## Notes
 
 - **Commits** are collected from each repository's **default branch** only; commits on other branches are not included.
+- With `--user`, events are collected for that user, but only from repositories the **token** can see: another user's activity in private repositories appears (with `--visibility private` or `all`) only when the token also has read access to those repositories.
 - Repositories with `INTERNAL` visibility (organization-internal repositories on GitHub Enterprise) are treated as private: they are included with `--visibility private` and `--visibility all`, and excluded with `--visibility public`.
 - Event types are fetched one at a time (not concurrently) to stay within GitHub's secondary rate limits. Transient API failures — rate limits and gateway errors — are retried up to 3 times, honoring the server-suggested wait when provided and falling back to exponential backoff. If fetching still fails, the error names the event type that was being fetched.
 - GitHub's Search API returns at most 1,000 results per query. When a query would exceed that cap, the date range is automatically split into smaller windows and searched again. If a single UTC day still exceeds the cap, the excess items are skipped and a warning is printed.

--- a/cspell.json
+++ b/cspell.json
@@ -219,6 +219,7 @@
     "aquasecurity",
     "misconfig",
     "worktree",
-    "worktrees"
+    "worktrees",
+    "octocat"
   ]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ async function main(): Promise<void> {
 
     const service = new GitHubService({
       token,
+      username: options.user,
       since: options.since,
       until: options.until,
       visibility: options.visibility,

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -32,6 +32,24 @@ describe("parseCliArgs", () => {
     expect(result.order).toBe("desc");
   });
 
+  it("parses --user", () => {
+    expect(parseCliArgs(["--user", "octocat"]).user).toBe("octocat");
+    expect(parseCliArgs(["--user", "my-name-1"]).user).toBe("my-name-1");
+  });
+
+  it("leaves user undefined unless --user is passed", () => {
+    expect(parseCliArgs([]).user).toBeUndefined();
+  });
+
+  it("throws on an invalid --user value", () => {
+    expect(() => parseCliArgs(["--user", ""])).toThrow(/--user/);
+    expect(() => parseCliArgs(["--user", "-leading-hyphen"])).toThrow(/--user/);
+    expect(() => parseCliArgs(["--user", "trailing-hyphen-"])).toThrow(/--user/);
+    expect(() => parseCliArgs(["--user", "double--hyphen"])).toThrow(/--user/);
+    expect(() => parseCliArgs(["--user", "has space"])).toThrow(/--user/);
+    expect(() => parseCliArgs(["--user", "a".repeat(40)])).toThrow(/--user/);
+  });
+
   it("uses defaults when no options provided", () => {
     const result = parseCliArgs([]);
     expect(result.output).toBe("./ghactivities.json");

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -35,6 +35,9 @@ describe("parseCliArgs", () => {
   it("parses --user", () => {
     expect(parseCliArgs(["--user", "octocat"]).user).toBe("octocat");
     expect(parseCliArgs(["--user", "my-name-1"]).user).toBe("my-name-1");
+    // 39 characters, hyphens included, is the longest valid login.
+    expect(parseCliArgs(["--user", "a".repeat(39)]).user).toBe("a".repeat(39));
+    expect(parseCliArgs(["--user", "a-b".repeat(13)]).user).toBe("a-b".repeat(13));
   });
 
   it("leaves user undefined unless --user is passed", () => {
@@ -43,11 +46,16 @@ describe("parseCliArgs", () => {
 
   it("throws on an invalid --user value", () => {
     expect(() => parseCliArgs(["--user", ""])).toThrow(/--user/);
-    expect(() => parseCliArgs(["--user", "-leading-hyphen"])).toThrow(/--user/);
+    // The `--user=` form is required here: a space-separated value starting
+    // with a hyphen is rejected by parseArgs itself as an ambiguous option
+    // and would never reach the schema validation.
+    expect(() => parseCliArgs(["--user=-leading-hyphen"])).toThrow(/--user/);
     expect(() => parseCliArgs(["--user", "trailing-hyphen-"])).toThrow(/--user/);
     expect(() => parseCliArgs(["--user", "double--hyphen"])).toThrow(/--user/);
     expect(() => parseCliArgs(["--user", "has space"])).toThrow(/--user/);
     expect(() => parseCliArgs(["--user", "a".repeat(40)])).toThrow(/--user/);
+    // Hyphens count toward the 39-character cap.
+    expect(() => parseCliArgs(["--user", `a${"-b".repeat(20)}`])).toThrow(/--user/);
   });
 
   it("uses defaults when no options provided", () => {

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -4,12 +4,9 @@ import { z } from "zod/mini";
 import type { CliOptions, Order, Visibility } from "../types/cli.js";
 
 import packageJson from "../../package.json" with { type: "json" };
+import { GITHUB_LOGIN_PATTERN } from "../utils/github-login.js";
 import { parseSize } from "../utils/parse-size.js";
 import { resolveScanConfig } from "./parse-scan-args.js";
-
-// GitHub logins are 1-39 alphanumeric characters or hyphens, and a hyphen
-// cannot start, end, or repeat.
-const GITHUB_LOGIN_PATTERN = /^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$/;
 
 const ArgsSchema = z
   .object({
@@ -18,7 +15,7 @@ const ArgsSchema = z
       z.string().check(
         z.refine((v) => GITHUB_LOGIN_PATTERN.test(v), {
           message:
-            "Invalid GitHub username for --user. Expected 1-39 alphanumeric characters or hyphens, not starting or ending with a hyphen.",
+            "Invalid GitHub username for --user. Expected at most 39 alphanumeric characters or hyphens; a hyphen cannot start, end, or repeat.",
         }),
       ),
     ),

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -7,9 +7,21 @@ import packageJson from "../../package.json" with { type: "json" };
 import { parseSize } from "../utils/parse-size.js";
 import { resolveScanConfig } from "./parse-scan-args.js";
 
+// GitHub logins are 1-39 alphanumeric characters or hyphens, and a hyphen
+// cannot start, end, or repeat.
+const GITHUB_LOGIN_PATTERN = /^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$/;
+
 const ArgsSchema = z
   .object({
     githubToken: z.optional(z.string()),
+    user: z.optional(
+      z.string().check(
+        z.refine((v) => GITHUB_LOGIN_PATTERN.test(v), {
+          message:
+            "Invalid GitHub username for --user. Expected 1-39 alphanumeric characters or hyphens, not starting or ending with a hyphen.",
+        }),
+      ),
+    ),
     output: z.string(),
     since: z.string().check(
       z.refine((v) => !Number.isNaN(Date.parse(v)), {
@@ -73,6 +85,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     args: argv,
     options: {
       "github-token": { type: "string" },
+      user: { type: "string" },
       output: { type: "string", default: "./ghactivities.json" },
       since: { type: "string", default: getDefaultSince() },
       until: { type: "string", default: new Date().toISOString() },
@@ -105,6 +118,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
 
   const parsed = ArgsSchema.parse({
     githubToken: values["github-token"],
+    user: values.user,
     output: values.output,
     since: values.since,
     until: values.until,
@@ -127,6 +141,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
 
   return {
     githubToken: parsed.githubToken ?? "",
+    user: parsed.user,
     output: parsed.output,
     since: new Date(parsed.since),
     until: new Date(parsed.until),
@@ -145,6 +160,7 @@ Usage: ghactivities [options]
 
 Options:
   --github-token      GitHub access token (env: GITHUB_TOKEN or "gh auth token")
+  --user              GitHub username to collect activity for (default: the authenticated user)
   --output            Output file path (default: ./ghactivities.json)
   --since             Start date in ISO8601 format; must not be after --until (default: 2 weeks ago)
   --until             End date in ISO8601 format (default: now)

--- a/src/e2e/e2e-cli-args.spec.ts
+++ b/src/e2e/e2e-cli-args.spec.ts
@@ -29,7 +29,9 @@ describe("E2E: CLI option validation", () => {
   });
 
   it("rejects a malformed --user value", async () => {
-    await expect(runCli(["--user", "-not-a-login-"])).rejects.toMatchObject({
+    // The value must not start with a hyphen: parseArgs would reject it as an
+    // ambiguous option before the schema validation this test covers is run.
+    await expect(runCli(["--user", "not--a--login"])).rejects.toMatchObject({
       stdout: expect.stringMatching(/--user/),
     });
   });

--- a/src/e2e/e2e-cli-args.spec.ts
+++ b/src/e2e/e2e-cli-args.spec.ts
@@ -28,6 +28,12 @@ describe("E2E: CLI option validation", () => {
     });
   });
 
+  it("rejects a malformed --user value", async () => {
+    await expect(runCli(["--user", "-not-a-login-"])).rejects.toMatchObject({
+      stdout: expect.stringMatching(/--user/),
+    });
+  });
+
   it("rejects a malformed --max-length-size value", async () => {
     await expect(runCli(["--max-length-size", "abc"])).rejects.toMatchObject({
       stdout: expect.stringMatching(/max-length-size|size/i),

--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -363,11 +363,10 @@ export const COMMIT_HISTORY_QUERY = `
   }
 `;
 
-export const VIEWER_ID_QUERY = `
-  query {
-    viewer {
+export const USER_ID_QUERY = `
+  query ($login: String!) {
+    user(login: $login) {
       id
-      login
     }
   }
 `;

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -81,17 +81,17 @@ vi.mock("@octokit/graphql", () => {
     if (query.includes("defaultBranchRef")) {
       return Promise.resolve({ repository: { defaultBranchRef: null } });
     }
-    // Must come before the viewer-id fallback: these query texts contain "id".
     if (query.includes("node(id:")) {
       return Promise.resolve(handleNodePage(query, variables));
     }
     if (query.includes("search(type:")) {
       return Promise.resolve(handleSearch(variables));
     }
-    // The only remaining queries are the two viewer lookups; the id variant is
-    // the one that also selects the `id` field.
-    if (query.includes("id")) {
-      return Promise.resolve({ viewer: { id: "VIEWER_ID", login: "testuser" } });
+    // User id lookup (commit author filter and the --user existence check).
+    // The contributionsCollection query also selects user(login:) but is
+    // already handled above.
+    if (query.includes("user(login:")) {
+      return Promise.resolve({ user: { id: "USER_ID" } });
     }
     return Promise.resolve({ viewer: { login: "testuser" } });
   };
@@ -110,6 +110,7 @@ beforeEach(() => {
 });
 
 const makeService = (params?: {
+  username?: string;
   since?: Date;
   until?: Date;
   visibility?: "public" | "private" | "all";
@@ -118,6 +119,7 @@ const makeService = (params?: {
 }) =>
   new GitHubService({
     token: "test-token",
+    username: params?.username,
     since: params?.since ?? new Date("2024-01-01T00:00:00Z"),
     until: params?.until ?? new Date("2024-01-15T00:00:00Z"),
     visibility: params?.visibility ?? "public",
@@ -670,6 +672,60 @@ describe("computeRetryDelayMs", () => {
     const error = { headers: { "retry-after": "soon", "x-ratelimit-reset": "-5" } };
     expect(computeRetryDelayMs({ error, attempt: 0, baseDelayMs: 1000 })).toBe(1000);
     expect(computeRetryDelayMs({ error, attempt: 2, baseDelayMs: 1000 })).toBe(4000);
+  });
+});
+
+describe("username override", () => {
+  it("resolves the viewer login when no username is given", async () => {
+    await makeService().fetchAllEvents();
+
+    const viewerCalls = calls.filter((call) => call.query.includes("viewer"));
+    expect(viewerCalls.length).toBeGreaterThan(0);
+
+    const searchQueries = calls
+      .map((call) => call.variables.searchQuery)
+      .filter((value): value is string => typeof value === "string");
+    expect(searchQueries.some((q) => q.includes("author:testuser"))).toBe(true);
+  });
+
+  it("searches as the given username and never queries the viewer", async () => {
+    await makeService({ username: "octocat" }).fetchAllEvents();
+
+    const viewerCalls = calls.filter((call) => call.query.includes("viewer"));
+    expect(viewerCalls).toEqual([]);
+
+    const searchQueries = calls
+      .map((call) => call.variables.searchQuery)
+      .filter((value): value is string => typeof value === "string");
+    expect(searchQueries.some((q) => q.includes("author:octocat"))).toBe(true);
+    expect(searchQueries.some((q) => q.includes("commenter:octocat"))).toBe(true);
+    expect(searchQueries.some((q) => q.includes("reviewed-by:octocat"))).toBe(true);
+    expect(searchQueries.some((q) => q.includes("testuser"))).toBe(false);
+
+    // The commit contributions lookup must target the given user too.
+    const contributionCalls = calls.filter((call) =>
+      call.query.includes("contributionsCollection"),
+    );
+    expect(contributionCalls.length).toBeGreaterThan(0);
+    for (const call of contributionCalls) {
+      expect(call.variables.login).toBe("octocat");
+    }
+  });
+
+  it("fails fast with a clear error when the given user does not exist", async () => {
+    // `($login: String!) {` (immediately closed) only appears in the user-id
+    // query; the contributions query declares more variables.
+    failures.set("($login: String!) {", [
+      new Error("Could not resolve to a User with the login of 'ghost'."),
+    ]);
+
+    await expect(makeService({ username: "ghost" }).fetchAllEvents()).rejects.toThrow(
+      'Failed to fetch user "ghost"',
+    );
+
+    // No search must have been attempted after the failed lookup.
+    const searchCalls = calls.filter((call) => call.query.includes("search(type:"));
+    expect(searchCalls).toEqual([]);
   });
 });
 

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -712,6 +712,13 @@ describe("username override", () => {
     }
   });
 
+  it("rejects a username that could inject extra search qualifiers", async () => {
+    await expect(makeService({ username: "x is:public" }).fetchAllEvents()).rejects.toThrow(
+      "Invalid GitHub username",
+    );
+    expect(calls).toEqual([]);
+  });
+
   it("fails fast with a clear error when the given user does not exist", async () => {
     // `($login: String!) {` (immediately closed) only appears in the user-id
     // query; the contributions query declares more variables.

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -32,6 +32,7 @@ import {
   toUtcDayString,
 } from "../utils/date-range.js";
 import { formatError } from "../utils/error.js";
+import { GITHUB_LOGIN_PATTERN } from "../utils/github-login.js";
 import {
   COMMIT_HISTORY_QUERY,
   CONTRIBUTIONS_COLLECTION_QUERY,
@@ -125,6 +126,9 @@ export function computeRetryDelayMs(params: {
 export class GitHubService {
   private readonly graphqlWithAuth: typeof graphql;
   private readonly username: string | undefined;
+  // Caches the id lookup, which runs both as the up-front --user existence
+  // check and for the commit history author filter.
+  private userIdCache: { login: string; id: string } | undefined;
   private readonly since: Date;
   private readonly until: Date;
   private readonly visibility: Visibility;
@@ -155,6 +159,12 @@ export class GitHubService {
       }
     } else {
       username = this.username;
+      // Defense in depth: the CLI already validates --user, but the username
+      // is interpolated into search query strings, so a caller bypassing the
+      // CLI must not be able to inject extra search qualifiers.
+      if (!GITHUB_LOGIN_PATTERN.test(username)) {
+        throw new Error(`Invalid GitHub username: "${username}"`);
+      }
       // Resolving the id up front makes a nonexistent --user fail fast with a
       // clear error instead of six empty searches followed by a commit failure.
       try {
@@ -222,17 +232,13 @@ export class GitHubService {
     return response.viewer.login;
   }
 
-  // Cached: the id is resolved once per run but needed both for the up-front
-  // --user existence check and for the commit history author filter.
-  private userIdCache: string | undefined;
-
   private async getUserId(login: string): Promise<string> {
-    if (this.userIdCache !== undefined) return this.userIdCache;
+    if (this.userIdCache?.login === login) return this.userIdCache.id;
     const response = await this.execute<UserIdResponse>(USER_ID_QUERY, { login });
     if (!response.user) {
       throw new Error(`GitHub user "${login}" was not found`);
     }
-    this.userIdCache = response.user.id;
+    this.userIdCache = { login, id: response.user.id };
     return response.user.id;
   }
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -20,6 +20,7 @@ import type {
   ReviewsConnection,
   ReviewsPageResponse,
   SearchResponse,
+  UserIdResponse,
   ViewerResponse,
 } from "../types/github-api.js";
 import type { DateRange } from "../utils/date-range.js";
@@ -46,12 +47,14 @@ import {
   PULL_REQUEST_SEARCH_QUERY,
   REVIEW_COMMENTS_PAGE_QUERY,
   REVIEWS_PAGE_QUERY,
-  VIEWER_ID_QUERY,
+  USER_ID_QUERY,
   VIEWER_QUERY,
 } from "./github-queries.js";
 
 interface GitHubServiceParams {
   token: string;
+  /** Collect this user's activity instead of the authenticated user's. */
+  username?: string | undefined;
   since: Date;
   until: Date;
   visibility: Visibility;
@@ -121,6 +124,7 @@ export function computeRetryDelayMs(params: {
 
 export class GitHubService {
   private readonly graphqlWithAuth: typeof graphql;
+  private readonly username: string | undefined;
   private readonly since: Date;
   private readonly until: Date;
   private readonly visibility: Visibility;
@@ -132,6 +136,7 @@ export class GitHubService {
     this.graphqlWithAuth = graphql.defaults({
       headers: { authorization: `token ${params.token}` },
     });
+    this.username = params.username;
     this.since = params.since;
     this.until = params.until;
     this.visibility = params.visibility;
@@ -142,10 +147,23 @@ export class GitHubService {
 
   async fetchAllEvents(): Promise<GitHubEvent[]> {
     let username: string;
-    try {
-      username = await this.getViewerLogin();
-    } catch (error) {
-      throw new Error(`Failed to fetch viewer login: ${formatError(error)}`, { cause: error });
+    if (this.username === undefined) {
+      try {
+        username = await this.getViewerLogin();
+      } catch (error) {
+        throw new Error(`Failed to fetch viewer login: ${formatError(error)}`, { cause: error });
+      }
+    } else {
+      username = this.username;
+      // Resolving the id up front makes a nonexistent --user fail fast with a
+      // clear error instead of six empty searches followed by a commit failure.
+      try {
+        await this.getUserId(username);
+      } catch (error) {
+        throw new Error(`Failed to fetch user "${username}": ${formatError(error)}`, {
+          cause: error,
+        });
+      }
     }
 
     // Fetchers run one at a time: GitHub's secondary rate-limit guidance is to
@@ -204,11 +222,18 @@ export class GitHubService {
     return response.viewer.login;
   }
 
-  private async getViewerId(): Promise<string> {
-    const response = await this.execute<{
-      viewer: { id: string; login: string };
-    }>(VIEWER_ID_QUERY);
-    return response.viewer.id;
+  // Cached: the id is resolved once per run but needed both for the up-front
+  // --user existence check and for the commit history author filter.
+  private userIdCache: string | undefined;
+
+  private async getUserId(login: string): Promise<string> {
+    if (this.userIdCache !== undefined) return this.userIdCache;
+    const response = await this.execute<UserIdResponse>(USER_ID_QUERY, { login });
+    if (!response.user) {
+      throw new Error(`GitHub user "${login}" was not found`);
+    }
+    this.userIdCache = response.user.id;
+    return response.user.id;
   }
 
   // Search qualifiers match the parent issue/PR/discussion, not its comments.
@@ -632,7 +657,7 @@ export class GitHubService {
 
   private async fetchCommits(username: string): Promise<GitHubEvent[]> {
     const events: GitHubEvent[] = [];
-    const viewerId = await this.getViewerId();
+    const authorId = await this.getUserId(username);
     const periods = splitDateRangeIntoYearPeriods({
       since: this.since,
       until: this.until,
@@ -673,7 +698,7 @@ export class GitHubService {
             until: this.until.toISOString(),
             first: 100,
             after: cursor,
-            authorId: viewerId,
+            authorId,
           },
         );
 

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -5,6 +5,8 @@ export type Order = "asc" | "desc";
 
 export interface CliOptions {
   githubToken: string;
+  /** When set (via --user), activity of this user is collected instead of the authenticated user's. */
+  user?: string | undefined;
   output: string;
   since: Date;
   until: Date;

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -188,3 +188,9 @@ export interface ViewerResponse {
     login: string;
   };
 }
+
+export interface UserIdResponse {
+  user: {
+    id: string;
+  } | null;
+}

--- a/src/utils/github-login.ts
+++ b/src/utils/github-login.ts
@@ -1,0 +1,4 @@
+// GitHub logins are at most 39 characters of alphanumerics or hyphens, and a
+// hyphen cannot start, end, or repeat. The lookahead makes each repetition
+// consume exactly one character, so hyphens count toward the 39-character cap.
+export const GITHUB_LOGIN_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;


### PR DESCRIPTION
## Summary

Adds a `--user` option that collects the GitHub activity of the specified user instead of the authenticated user.

- `--user <login>` is validated against GitHub's username rules (1-39 alphanumeric characters or hyphens; no leading, trailing, or consecutive hyphens) in the `zod/mini` schema, and listed in `--help` and the README options table.
- When `--user` is set, `GitHubService` skips the `viewer` lookup and runs all `author:` / `commenter:` / `reviewed-by:` searches and the commit collection as the given user.
- The commit author-id lookup now uses a single `user(login:) { id }` query (`USER_ID_QUERY`) for both modes, replacing `VIEWER_ID_QUERY`; the id is fetched once and cached.
- A nonexistent `--user` fails fast with `Failed to fetch user "<login>"` before any search runs, instead of six empty searches followed by a commit-phase failure.
- A token is still required for API access; another user's private-repo activity appears (with `--visibility private`/`all`) only when the token can read those repositories (documented in README Notes).

## Test plan

- Unit tests: `--user` parsing/validation, searching as the given username without querying the viewer, and fail-fast on a nonexistent user.
- E2E test: malformed `--user` value is rejected before any GitHub API call.
- `pnpm cicheck` and `pnpm run test:e2e` pass locally (93 unit tests, 18 E2E tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)