### PR TITLE
feat: add audit-oriented event types and commit collection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To include private repositories (`--visibility private` or `--visibility all`), 
 
 Events are written as a pretty-printed JSON array, sorted by `createdAt` according to `--order`.
 
-Each event shares a common shape and adds type-specific fields:
+Each event shares a common shape (`type`, `createdAt`, `repository`) and adds type-specific fields — for example, Commit events always carry a `branches` list (plus a `diff` file list with `--commit-diff`), comment events carry an `editHistory` list when the comment was edited, and Gist events carry a `files` list with file contents:
 
 ```json
 [
@@ -126,6 +126,8 @@ npx ghactivities scan ./ghactivities.json --provider openai
 ## Scanning activity with an LLM
 
 The `scan` subcommand reads the JSON produced by `ghactivities` and asks a large language model (via the [Vercel AI SDK](https://ai-sdk.dev/)) to summarize your activity into a Markdown report.
+
+Note that everything in the collected JSON — comment bodies and edit histories, gist file contents, READMEs, and commit diffs — is sent to the selected LLM provider. Review the collected data (or narrow what you collect) before scanning if it may contain sensitive content.
 
 ```bash
 # Scan a single file
@@ -180,8 +182,8 @@ For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vert
 
 - **Commits** are collected from each repository's **default branch** by default. With `--branches all`, every branch is scanned and each commit is emitted once with a `branches` list of the branches it was found on. Repository discovery is based on GitHub's contribution data (default-branch commits) plus, with `--branches all`, your own repositories pushed within the range — branches of repositories you do not own and never committed to on the default branch can still be missed.
 - **Gists** need gist read access on the token (the `gist` scope on classic tokens, or the Gists permission on fine-grained tokens). Without it, gists are skipped with a warning instead of failing the run.
-- **Releases** are discovered by walking the user's **own** repositories; releases published in repositories owned by someone else are not collected.
-- **Repository** events cover repositories **created** within the range; a repository that was switched from private to public is not detected as an event (GitHub exposes no such timestamp).
+- **Releases** are discovered by walking the user's **own** repositories; releases published in repositories owned by someone else are not collected. A release counts from its publication time (`publishedAt`), but the scan stops at releases **created** before `--since` — a release drafted before the range and published inside it is not collected.
+- **Repository** events cover repositories **created** within the range; a repository that was switched from private to public is not detected as an event (GitHub exposes no such timestamp). The `readme` field reads exactly `README.md` on the default branch — other spellings (`readme.md`, `README.rst`, a plain `README` with no extension) come back as `null`.
 - **WikiPageEdit** events come from the GitHub events feed, which only covers the most recent **90 days** and at most **300 events** per user; a warning is printed when the requested range cannot be fully covered.
 - **editHistory** on comment events contains at most the 5 most recent prior revisions of an edited comment.
 - With `--user`, events are collected for that user, but only from repositories the **token** can see: another user's activity in private repositories appears (with `--visibility private` or `all`) only when the token also has read access to those repositories.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ghactivities
 
-A CLI tool that collects your GitHub activity — issues, issue comments, discussions, discussion comments, pull requests, pull request comments, pull request review comments, and commits — and writes them to a JSON file.
+A CLI tool that collects your GitHub activity — issues, comments, discussions, pull requests, reviews, commits, commit comments, gists, releases, repositories, and wiki edits — and writes them to a JSON file.
 
 ## Features
 
@@ -13,7 +13,14 @@ Fetches the following events authored by you — or by any user given with `--us
 - **PullRequest** — pull requests you opened
 - **PullRequestComment** — conversation comments you left on pull requests
 - **PullRequestReviewComment** — review feedback you left on pull requests (review summary bodies and inline review comments on the diff)
-- **Commit** — commits you authored (on each repository's default branch)
+- **Commit** — commits you authored (on each repository's default branch, or on every branch with `--branches all`; add per-file diffs with `--commit-diff`)
+- **CommitComment** — comments you left directly on commits
+- **Gist** — gists you created, including file contents (secret gists count as private)
+- **Release** — releases you published in your own repositories, including release notes and asset metadata
+- **Repository** — repositories you created, including their description and README
+- **WikiPageEdit** — wiki pages you created or edited (from the GitHub events feed; see [Notes](#notes))
+
+Comment events additionally carry an `editHistory` field with the prior revisions (up to the 5 most recent edits) when a comment has been edited — useful for auditing content that was posted and then reworded or removed.
 
 It can also **scan** the collected JSON with an LLM to produce a Markdown summary report — see [Scanning activity with an LLM](#scanning-activity-with-an-llm).
 
@@ -52,6 +59,8 @@ To include private repositories (`--visibility private` or `--visibility all`), 
 | `--since`           | Start of the range, in ISO 8601 format. Must not be later than `--until`.                                                                                                                  | 2 weeks ago                              |
 | `--until`           | End of the range, in ISO 8601 format.                                                                                                                                                      | now                                      |
 | `--visibility`      | Repository visibility: `public`, `private`, or `all`.                                                                                                                                      | `public`                                 |
+| `--branches`        | Commit collection scope: `default` (each repository's default branch) or `all` (every branch, deduplicated; each commit lists the branches it was seen on).                                | `default`                                |
+| `--commit-diff`     | Attach per-file diffs (`diff` field) to Commit events. Costs one extra API request per commit.                                                                                             | off                                      |
 | `--max-length-size` | Maximum output file size (e.g. `1B`, `2K`, `2M`, `1G`). Larger output is split across multiple files.                                                                                      | `1M`                                     |
 | `--max-tokens`      | Maximum number of tokens per output file (counted with `js-tiktoken`'s `cl100k_base` encoding). Output is split when a file would exceed this. Applied in addition to `--max-length-size`. | (disabled)                               |
 | `--order`           | Event order by date: `asc` or `desc`.                                                                                                                                                      | `asc`                                    |
@@ -97,6 +106,9 @@ npx ghactivities
 
 # Collect another user's public activity
 npx ghactivities --user octocat
+
+# Audit-oriented collection: every branch, with commit diffs
+npx ghactivities --branches all --commit-diff
 
 # Collect a specific range, including private repositories
 npx ghactivities \
@@ -166,7 +178,12 @@ For `vertexai`, an API key uses Vertex AI express mode. You can also set `--vert
 
 ## Notes
 
-- **Commits** are collected from each repository's **default branch** only; commits on other branches are not included.
+- **Commits** are collected from each repository's **default branch** by default. With `--branches all`, every branch is scanned and each commit is emitted once with a `branches` list of the branches it was found on. Repository discovery is based on GitHub's contribution data (default-branch commits) plus, with `--branches all`, your own repositories pushed within the range — branches of repositories you do not own and never committed to on the default branch can still be missed.
+- **Gists** need gist read access on the token (the `gist` scope on classic tokens, or the Gists permission on fine-grained tokens). Without it, gists are skipped with a warning instead of failing the run.
+- **Releases** are discovered by walking the user's **own** repositories; releases published in repositories owned by someone else are not collected.
+- **Repository** events cover repositories **created** within the range; a repository that was switched from private to public is not detected as an event (GitHub exposes no such timestamp).
+- **WikiPageEdit** events come from the GitHub events feed, which only covers the most recent **90 days** and at most **300 events** per user; a warning is printed when the requested range cannot be fully covered.
+- **editHistory** on comment events contains at most the 5 most recent prior revisions of an edited comment.
 - With `--user`, events are collected for that user, but only from repositories the **token** can see: another user's activity in private repositories appears (with `--visibility private` or `all`) only when the token also has read access to those repositories.
 - Repositories with `INTERNAL` visibility (organization-internal repositories on GitHub Enterprise) are treated as private: they are included with `--visibility private` and `--visibility all`, and excluded with `--visibility public`.
 - Event types are fetched one at a time (not concurrently) to stay within GitHub's secondary rate limits. Transient API failures — rate limits and gateway errors — are retried up to 3 times, honoring the server-suggested wait when provided and falling back to exponential backoff. If fetching still fails, the error names the event type that was being fetched.

--- a/cspell.json
+++ b/cspell.json
@@ -220,6 +220,7 @@
     "misconfig",
     "worktree",
     "worktrees",
-    "octocat"
+    "octocat",
+    "Gollum"
   ]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -42,6 +42,8 @@ async function main(): Promise<void> {
       since: options.since,
       until: options.until,
       visibility: options.visibility,
+      branches: options.branches,
+      commitDiff: options.commitDiff,
       onWarning: (message) => {
         p.log.warn(message);
       },

--- a/src/cli/parse-args.test.ts
+++ b/src/cli/parse-args.test.ts
@@ -58,10 +58,22 @@ describe("parseCliArgs", () => {
     expect(() => parseCliArgs(["--user", `a${"-b".repeat(20)}`])).toThrow(/--user/);
   });
 
+  it("parses --branches and --commit-diff", () => {
+    const result = parseCliArgs(["--branches", "all", "--commit-diff"]);
+    expect(result.branches).toBe("all");
+    expect(result.commitDiff).toBe(true);
+  });
+
+  it("throws on an invalid --branches value", () => {
+    expect(() => parseCliArgs(["--branches", "sideways"])).toThrow();
+  });
+
   it("uses defaults when no options provided", () => {
     const result = parseCliArgs([]);
     expect(result.output).toBe("./ghactivities.json");
     expect(result.visibility).toBe("public");
+    expect(result.branches).toBe("default");
+    expect(result.commitDiff).toBe(false);
     expect(result.maxLengthSize).toBe(1024 * 1024);
     expect(result.maxTokens).toBeUndefined();
     expect(result.order).toBe("asc");

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,7 +1,7 @@
 import { parseArgs as nodeParseArgs } from "node:util";
 import { z } from "zod/mini";
 
-import type { CliOptions, Order, Visibility } from "../types/cli.js";
+import type { Branches, CliOptions, Order, Visibility } from "../types/cli.js";
 
 import packageJson from "../../package.json" with { type: "json" };
 import { GITHUB_LOGIN_PATTERN } from "../utils/github-login.js";
@@ -31,6 +31,8 @@ const ArgsSchema = z
       }),
     ),
     visibility: z.enum(["public", "private", "all"]),
+    branches: z.enum(["default", "all"]),
+    commitDiff: z.boolean(),
     maxLengthSize: z.string().check(
       z.refine(
         (v) => {
@@ -87,6 +89,8 @@ export function parseCliArgs(argv: string[]): CliOptions {
       since: { type: "string", default: getDefaultSince() },
       until: { type: "string", default: new Date().toISOString() },
       visibility: { type: "string", default: "public" },
+      branches: { type: "string", default: "default" },
+      "commit-diff": { type: "boolean", default: false },
       "max-length-size": { type: "string", default: "1M" },
       "max-tokens": { type: "string" },
       order: { type: "string", default: "asc" },
@@ -120,6 +124,8 @@ export function parseCliArgs(argv: string[]): CliOptions {
     since: values.since,
     until: values.until,
     visibility: values.visibility,
+    branches: values.branches,
+    commitDiff: values["commit-diff"],
     maxLengthSize: values["max-length-size"],
     maxTokens: values["max-tokens"],
     order: values.order,
@@ -143,6 +149,8 @@ export function parseCliArgs(argv: string[]): CliOptions {
     since: new Date(parsed.since),
     until: new Date(parsed.until),
     visibility: parsed.visibility as Visibility,
+    branches: parsed.branches as Branches,
+    commitDiff: parsed.commitDiff,
     maxLengthSize: parseSize(parsed.maxLengthSize),
     maxTokens: parsed.maxTokens === undefined ? undefined : Number(parsed.maxTokens.trim()),
     order: parsed.order as Order,
@@ -162,6 +170,8 @@ Options:
   --since             Start date in ISO8601 format; must not be after --until (default: 2 weeks ago)
   --until             End date in ISO8601 format (default: now)
   --visibility        Repository visibility: public, private, all (default: public)
+  --branches          Commit collection scope: default (default branch only), all (every branch) (default: default)
+  --commit-diff       Attach per-file diffs to Commit events (one extra API call per commit)
   --max-length-size   Max output file size: e.g., 1B, 2K, 2M (default: 1M)
   --max-tokens        Max tokens per output file (js-tiktoken, cl100k_base); splits when exceeded
   --order             Event order: asc, desc (default: asc)

--- a/src/e2e/e2e-cli-args.spec.ts
+++ b/src/e2e/e2e-cli-args.spec.ts
@@ -14,6 +14,12 @@ describe("E2E: CLI option validation", () => {
     });
   });
 
+  it("rejects an invalid --branches value", async () => {
+    await expect(runCli(["--branches", "sideways"])).rejects.toMatchObject({
+      stdout: expect.stringMatching(/branches/i),
+    });
+  });
+
   it("rejects an invalid --visibility value", async () => {
     await expect(runCli(["--visibility", "secret"])).rejects.toMatchObject({
       stdout: expect.stringMatching(/visibility/i),

--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -6,6 +6,19 @@ export const VIEWER_QUERY = `
   }
 `;
 
+// Prior revisions of an edited comment (newest first). Capped at 5 per
+// comment: the review search already nests PR > reviews > comments, and a
+// larger page would push the query over GitHub's 500,000-node limit.
+const CONTENT_EDIT_FIELDS = `
+  userContentEdits(first: 5) {
+    nodes {
+      editedAt
+      deletedAt
+      diff
+    }
+  }
+`;
+
 export const ISSUE_SEARCH_QUERY = `
   query ($searchQuery: String!, $first: Int!, $after: String) {
     search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
@@ -60,6 +73,7 @@ export const ISSUE_COMMENT_SEARCH_QUERY = `
               url
               createdAt
               author { login }
+              ${CONTENT_EDIT_FIELDS}
             }
           }
         }
@@ -122,6 +136,7 @@ export const DISCUSSION_COMMENT_SEARCH_QUERY = `
               url
               createdAt
               author { login }
+              ${CONTENT_EDIT_FIELDS}
             }
           }
         }
@@ -184,6 +199,7 @@ export const PULL_REQUEST_COMMENT_SEARCH_QUERY = `
               url
               createdAt
               author { login }
+              ${CONTENT_EDIT_FIELDS}
             }
           }
         }
@@ -211,6 +227,7 @@ const buildCommentsPageQuery = (
             url
             createdAt
             author { login }
+            ${CONTENT_EDIT_FIELDS}
           }
         }
       }
@@ -238,6 +255,7 @@ const REVIEW_FIELDS = `
   createdAt
   submittedAt
   author { login }
+  ${CONTENT_EDIT_FIELDS}
   comments(first: 25) {
     pageInfo {
       hasNextPage
@@ -248,6 +266,7 @@ const REVIEW_FIELDS = `
       url
       createdAt
       author { login }
+      ${CONTENT_EDIT_FIELDS}
     }
   }
 `;
@@ -339,6 +358,7 @@ export const COMMIT_HISTORY_QUERY = `
   query ($owner: String!, $name: String!, $since: GitTimestamp!, $until: GitTimestamp!, $first: Int!, $after: String, $authorId: ID!) {
     repository(owner: $owner, name: $name) {
       defaultBranchRef {
+        name
         target {
           ... on Commit {
             history(since: $since, until: $until, first: $first, after: $after, author: { id: $authorId }) {
@@ -367,6 +387,214 @@ export const USER_ID_QUERY = `
   query ($login: String!) {
     user(login: $login) {
       id
+    }
+  }
+`;
+
+export const BRANCH_REFS_QUERY = `
+  query ($owner: String!, $name: String!, $first: Int!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      refs(refPrefix: "refs/heads/", first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const BRANCH_COMMIT_HISTORY_QUERY = `
+  query ($owner: String!, $name: String!, $qualifiedName: String!, $since: GitTimestamp!, $until: GitTimestamp!, $first: Int!, $after: String, $authorId: ID!) {
+    repository(owner: $owner, name: $name) {
+      ref(qualifiedName: $qualifiedName) {
+        target {
+          ... on Commit {
+            history(since: $since, until: $until, first: $first, after: $after, author: { id: $authorId }) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                oid
+                message
+                url
+                committedDate
+                author {
+                  user { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GISTS_QUERY = `
+  query ($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      gists(privacy: ALL, first: $first, after: $after, orderBy: { field: CREATED_AT, direction: DESC }) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          name
+          description
+          url
+          createdAt
+          isPublic
+          files(limit: 50) {
+            name
+            size
+            text
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const COMMIT_COMMENTS_QUERY = `
+  query ($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      commitComments(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          body
+          url
+          createdAt
+          commit { oid }
+          repository {
+            owner { login }
+            name
+            visibility
+          }
+          ${CONTENT_EDIT_FIELDS}
+        }
+      }
+    }
+  }
+`;
+
+const RELEASE_FIELDS = `
+  name
+  tagName
+  url
+  createdAt
+  description
+  isPrerelease
+  isDraft
+  author { login }
+  releaseAssets(first: 50) {
+    nodes {
+      name
+      downloadUrl
+      size
+      contentType
+    }
+  }
+`;
+
+// The releases connection is ordered newest-first so the per-repository scan
+// can stop as soon as it reaches a release older than --since.
+export const REPOSITORIES_WITH_RELEASES_QUERY = `
+  query ($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      repositories(ownerAffiliations: [OWNER], first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          owner { login }
+          name
+          visibility
+          releases(first: 25, orderBy: { field: CREATED_AT, direction: DESC }) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              ${RELEASE_FIELDS}
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const RELEASES_PAGE_QUERY = `
+  query ($owner: String!, $name: String!, $first: Int!, $after: String!) {
+    repository(owner: $owner, name: $name) {
+      releases(first: $first, after: $after, orderBy: { field: CREATED_AT, direction: DESC }) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          ${RELEASE_FIELDS}
+        }
+      }
+    }
+  }
+`;
+
+// Newest-first so the scan can stop at the first repository created before
+// --since. The object expression reads README.md from the default branch.
+export const CREATED_REPOSITORIES_QUERY = `
+  query ($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      repositories(ownerAffiliations: [OWNER], first: $first, after: $after, orderBy: { field: CREATED_AT, direction: DESC }) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          owner { login }
+          name
+          visibility
+          url
+          description
+          createdAt
+          isFork
+          object(expression: "HEAD:README.md") {
+            ... on Blob {
+              text
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Newest-pushed-first so the --branches all repository discovery can stop at
+// the first repository whose last push predates --since.
+export const PUSHED_REPOSITORIES_QUERY = `
+  query ($login: String!, $first: Int!, $after: String) {
+    user(login: $login) {
+      repositories(ownerAffiliations: [OWNER], first: $first, after: $after, orderBy: { field: PUSHED_AT, direction: DESC }) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          owner { login }
+          name
+          visibility
+          pushedAt
+        }
+      }
     }
   }
 `;

--- a/src/services/github-queries.ts
+++ b/src/services/github-queries.ts
@@ -490,6 +490,7 @@ const RELEASE_FIELDS = `
   tagName
   url
   createdAt
+  publishedAt
   description
   isPrerelease
   isDraft

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -14,6 +14,17 @@ const {
   reviewPagesByCursor,
   searchResponsesByQuery,
   failures,
+  contributionRepos,
+  defaultBranchHistoryNodes,
+  branchRefNodes,
+  branchHistoryByRef,
+  gistNodes,
+  commitCommentNodes,
+  releaseRepoNodes,
+  createdRepoNodes,
+  pushedRepoNodes,
+  restCalls,
+  restResponsesByPath,
 } = vi.hoisted(() => ({
   calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
   issueCommentSearchNodes: [] as unknown[],
@@ -25,6 +36,18 @@ const {
   // whose query or searchQuery contains the substring reject with the next
   // error from the list.
   failures: new Map<string, unknown[]>(),
+  // Nodes served to the commit/gist/release/repository/wiki fetchers.
+  contributionRepos: [] as unknown[],
+  defaultBranchHistoryNodes: [] as unknown[],
+  branchRefNodes: [] as unknown[],
+  branchHistoryByRef: new Map<string, unknown[]>(),
+  gistNodes: [] as unknown[],
+  commitCommentNodes: [] as unknown[],
+  releaseRepoNodes: [] as unknown[],
+  createdRepoNodes: [] as unknown[],
+  pushedRepoNodes: [] as unknown[],
+  restCalls: [] as string[],
+  restResponsesByPath: new Map<string, unknown>(),
 }));
 
 // Mock @octokit/graphql with a stub that returns empty-but-valid shapes for
@@ -67,6 +90,8 @@ vi.mock("@octokit/graphql", () => {
     };
   };
 
+  const noNextPage = { hasNextPage: false, endCursor: null };
+
   const impl = (query: string, variables: Record<string, unknown> = {}) => {
     calls.push({ query, variables });
 
@@ -75,11 +100,70 @@ vi.mock("@octokit/graphql", () => {
 
     if (query.includes("contributionsCollection")) {
       return Promise.resolve({
-        user: { contributionsCollection: { commitContributionsByRepository: [] } },
+        user: {
+          contributionsCollection: {
+            commitContributionsByRepository: contributionRepos.map((repository) => ({
+              repository,
+            })),
+          },
+        },
+      });
+    }
+    if (query.includes("refs(refPrefix:")) {
+      return Promise.resolve({
+        repository: { refs: { pageInfo: noNextPage, nodes: branchRefNodes } },
+      });
+    }
+    if (query.includes("ref(qualifiedName:")) {
+      const nodes = branchHistoryByRef.get(String(variables.qualifiedName)) ?? [];
+      return Promise.resolve({
+        repository: { ref: { target: { history: { pageInfo: noNextPage, nodes } } } },
       });
     }
     if (query.includes("defaultBranchRef")) {
-      return Promise.resolve({ repository: { defaultBranchRef: null } });
+      if (defaultBranchHistoryNodes.length === 0) {
+        return Promise.resolve({ repository: { defaultBranchRef: null } });
+      }
+      return Promise.resolve({
+        repository: {
+          defaultBranchRef: {
+            name: "main",
+            target: { history: { pageInfo: noNextPage, nodes: defaultBranchHistoryNodes } },
+          },
+        },
+      });
+    }
+    if (query.includes("gists(")) {
+      return Promise.resolve({
+        user: { gists: { pageInfo: noNextPage, nodes: gistNodes } },
+      });
+    }
+    if (query.includes("commitComments(")) {
+      return Promise.resolve({
+        user: { commitComments: { pageInfo: noNextPage, nodes: commitCommentNodes } },
+      });
+    }
+    // The per-repository releases page query selects repository { releases };
+    // the discovery query nests releases under user { repositories }.
+    if (query.includes("releases(first: $first")) {
+      return Promise.resolve({
+        repository: { releases: { pageInfo: noNextPage, nodes: [] } },
+      });
+    }
+    if (query.includes("releases(")) {
+      return Promise.resolve({
+        user: { repositories: { pageInfo: noNextPage, nodes: releaseRepoNodes } },
+      });
+    }
+    if (query.includes("pushedAt")) {
+      return Promise.resolve({
+        user: { repositories: { pageInfo: noNextPage, nodes: pushedRepoNodes } },
+      });
+    }
+    if (query.includes("isFork")) {
+      return Promise.resolve({
+        user: { repositories: { pageInfo: noNextPage, nodes: createdRepoNodes } },
+      });
     }
     if (query.includes("node(id:")) {
       return Promise.resolve(handleNodePage(query, variables));
@@ -99,6 +183,25 @@ vi.mock("@octokit/graphql", () => {
   return { graphql: Object.assign(impl, { defaults: () => impl }) };
 });
 
+// Stub the global fetch used by the service's REST calls (commit diffs and
+// the user events feed) so unit tests never touch the network.
+vi.stubGlobal(
+  "fetch",
+  vi.fn((url: string | URL) => {
+    const fullPath = String(url).replace("https://api.github.com", "");
+    restCalls.push(fullPath);
+    const preset =
+      restResponsesByPath.get(fullPath) ?? restResponsesByPath.get(fullPath.split("?")[0] ?? "");
+    const body = preset ?? (fullPath.startsWith("/users/") ? [] : { files: [] });
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: () => Promise.resolve(body),
+    } as unknown as Response);
+  }),
+);
+
 beforeEach(() => {
   calls.length = 0;
   issueCommentSearchNodes.length = 0;
@@ -107,6 +210,17 @@ beforeEach(() => {
   reviewPagesByCursor.clear();
   searchResponsesByQuery.clear();
   failures.clear();
+  contributionRepos.length = 0;
+  defaultBranchHistoryNodes.length = 0;
+  branchRefNodes.length = 0;
+  branchHistoryByRef.clear();
+  gistNodes.length = 0;
+  commitCommentNodes.length = 0;
+  releaseRepoNodes.length = 0;
+  createdRepoNodes.length = 0;
+  pushedRepoNodes.length = 0;
+  restCalls.length = 0;
+  restResponsesByPath.clear();
 });
 
 const makeService = (params?: {
@@ -114,6 +228,8 @@ const makeService = (params?: {
   since?: Date;
   until?: Date;
   visibility?: "public" | "private" | "all";
+  branches?: "default" | "all";
+  commitDiff?: boolean;
   onWarning?: (message: string) => void;
   retry?: { maxRetries?: number; baseDelayMs?: number };
 }) =>
@@ -123,6 +239,8 @@ const makeService = (params?: {
     since: params?.since ?? new Date("2024-01-01T00:00:00Z"),
     until: params?.until ?? new Date("2024-01-15T00:00:00Z"),
     visibility: params?.visibility ?? "public",
+    branches: params?.branches,
+    commitDiff: params?.commitDiff,
     ...(params?.onWarning ? { onWarning: params.onWarning } : {}),
     retry: params?.retry ?? { baseDelayMs: 1 },
   });
@@ -277,6 +395,12 @@ const issueNode = (title: string) => ({
   repository: { owner: { login: "owner" }, name: "repo", visibility: "PUBLIC" },
 });
 
+// The fixed 2024 test range lies more than 90 days in the past, so every full
+// fetchAllEvents run also emits the wiki events-feed coverage warning; tests
+// about other warnings filter it out.
+const withoutWikiFeedWarnings = (warnings: string[]) =>
+  warnings.filter((message) => !/wiki/i.test(message));
+
 describe("search result cap handling", () => {
   it("splits the date window in half when the result count exceeds the cap", async () => {
     const warnings: string[] = [];
@@ -302,7 +426,7 @@ describe("search result cap handling", () => {
 
     const issueTitles = events.filter((event) => event.type === "Issue").map((e) => e.title);
     expect(issueTitles).toEqual(["first-half", "second-half"]);
-    expect(warnings).toEqual([]);
+    expect(withoutWikiFeedWarnings(warnings)).toEqual([]);
   });
 
   it("keeps splitting when a half still exceeds the cap", async () => {
@@ -339,7 +463,7 @@ describe("search result cap handling", () => {
 
     const issueTitles = events.filter((event) => event.type === "Issue").map((e) => e.title);
     expect(issueTitles).toEqual(["first-quarter", "second-quarter", "second-half"]);
-    expect(warnings).toEqual([]);
+    expect(withoutWikiFeedWarnings(warnings)).toEqual([]);
   });
 
   it("warns instead of silently truncating when a single UTC day exceeds the cap", async () => {
@@ -358,9 +482,10 @@ describe("search result cap handling", () => {
 
     const issueTitles = events.filter((event) => event.type === "Issue").map((e) => e.title);
     expect(issueTitles).toEqual(["capped-day"]);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("1000");
-    expect(warnings[0]).toContain("author:testuser is:issue created:2024-01-05..2024-01-05");
+    const capWarnings = withoutWikiFeedWarnings(warnings);
+    expect(capWarnings).toHaveLength(1);
+    expect(capWarnings[0]).toContain("1000");
+    expect(capWarnings[0]).toContain("author:testuser is:issue created:2024-01-05..2024-01-05");
   });
 });
 
@@ -608,9 +733,10 @@ describe("transient failure handling", () => {
 
     const issueTitles = events.filter((event) => event.type === "Issue").map((e) => e.title);
     expect(issueTitles).toEqual(["recovered"]);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("retrying");
-    expect(warnings[0]).toContain("Bad gateway");
+    const retryWarnings = withoutWikiFeedWarnings(warnings);
+    expect(retryWarnings).toHaveLength(1);
+    expect(retryWarnings[0]).toContain("retrying");
+    expect(retryWarnings[0]).toContain("Bad gateway");
   });
 
   it("gives up after the retry budget and names the failing fetcher", async () => {
@@ -733,6 +859,426 @@ describe("username override", () => {
     // No search must have been attempted after the failed lookup.
     const searchCalls = calls.filter((call) => call.query.includes("search(type:"));
     expect(searchCalls).toEqual([]);
+  });
+});
+
+describe("audit event collection", () => {
+  const repoNode = { owner: { login: "owner" }, name: "repo", visibility: "PUBLIC" };
+
+  it("collects in-range gists and groups secret gists with private", async () => {
+    gistNodes.push(
+      {
+        name: "aaa111",
+        description: "public in range",
+        url: "https://gist.github.com/testuser/aaa111",
+        createdAt: "2024-01-05T00:00:00Z",
+        isPublic: true,
+        files: [{ name: "leak.txt", size: 10, text: "hello" }],
+      },
+      {
+        name: "bbb222",
+        description: "secret in range",
+        url: "https://gist.github.com/testuser/bbb222",
+        createdAt: "2024-01-04T00:00:00Z",
+        isPublic: false,
+        files: [],
+      },
+      {
+        name: "ccc333",
+        description: "public out of range",
+        url: "https://gist.github.com/testuser/ccc333",
+        createdAt: "2023-12-01T00:00:00Z",
+        isPublic: true,
+        files: [],
+      },
+    );
+
+    const publicEvents = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "Gist",
+    );
+    expect(publicEvents).toEqual([
+      {
+        type: "Gist",
+        createdAt: "2024-01-05T00:00:00Z",
+        description: "public in range",
+        url: "https://gist.github.com/testuser/aaa111",
+        files: [{ name: "leak.txt", size: 10, text: "hello" }],
+        repository: { owner: "testuser", name: "aaa111", visibility: "PUBLIC" },
+      },
+    ]);
+
+    const privateEvents = (await makeService({ visibility: "private" }).fetchAllEvents()).filter(
+      (event) => event.type === "Gist",
+    );
+    expect(privateEvents.map((event) => event.repository.name)).toEqual(["bbb222"]);
+  });
+
+  it("warns and skips gists when the token lacks gist access", async () => {
+    failures.set("gists(", [
+      Object.assign(new Error("Resource not accessible by personal access token"), {
+        errors: [{ type: "FORBIDDEN" }],
+      }),
+    ]);
+
+    const warnings: string[] = [];
+    const events = await makeService({
+      onWarning: (message) => warnings.push(message),
+    }).fetchAllEvents();
+
+    expect(events.filter((event) => event.type === "Gist")).toEqual([]);
+    expect(warnings.some((message) => message.includes("Gists could not be collected"))).toBe(true);
+  });
+
+  it("collects in-range commit comments with their edit history", async () => {
+    commitCommentNodes.push(
+      {
+        body: "current text",
+        url: "https://github.com/owner/repo/commit/abc#commitcomment-1",
+        createdAt: "2024-01-05T00:00:00Z",
+        commit: { oid: "abc123" },
+        repository: repoNode,
+        userContentEdits: {
+          nodes: [{ editedAt: "2024-01-05T01:00:00Z", deletedAt: null, diff: "previous text" }],
+        },
+      },
+      {
+        body: "out of range",
+        url: "https://github.com/owner/repo/commit/def#commitcomment-2",
+        createdAt: "2023-11-01T00:00:00Z",
+        commit: null,
+        repository: repoNode,
+        userContentEdits: null,
+      },
+    );
+
+    const events = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "CommitComment",
+    );
+    expect(events).toEqual([
+      {
+        type: "CommitComment",
+        createdAt: "2024-01-05T00:00:00Z",
+        body: "current text",
+        url: "https://github.com/owner/repo/commit/abc#commitcomment-1",
+        commitOid: "abc123",
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+        editHistory: [{ editedAt: "2024-01-05T01:00:00Z", deletedAt: null, diff: "previous text" }],
+      },
+    ]);
+  });
+
+  it("collects releases authored by the user from owned repositories", async () => {
+    releaseRepoNodes.push({
+      owner: { login: "testuser" },
+      name: "repo",
+      visibility: "PUBLIC",
+      releases: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            name: "v1.1.0",
+            tagName: "v1.1.0",
+            url: "https://github.com/testuser/repo/releases/tag/v1.1.0",
+            createdAt: "2024-01-10T00:00:00Z",
+            description: "notes",
+            isPrerelease: false,
+            isDraft: false,
+            author: { login: "testuser" },
+            releaseAssets: {
+              nodes: [
+                {
+                  name: "app.tgz",
+                  downloadUrl: "https://github.com/testuser/repo/releases/download/v1.1.0/app.tgz",
+                  size: 123,
+                  contentType: "application/gzip",
+                },
+              ],
+            },
+          },
+          {
+            name: "by someone else",
+            tagName: "v1.0.1",
+            url: "https://github.com/testuser/repo/releases/tag/v1.0.1",
+            createdAt: "2024-01-09T00:00:00Z",
+            description: null,
+            isPrerelease: false,
+            isDraft: false,
+            author: { login: "someone" },
+            releaseAssets: { nodes: [] },
+          },
+        ],
+      },
+    });
+
+    const events = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "Release",
+    );
+    expect(events).toEqual([
+      {
+        type: "Release",
+        createdAt: "2024-01-10T00:00:00Z",
+        title: "v1.1.0",
+        tagName: "v1.1.0",
+        url: "https://github.com/testuser/repo/releases/tag/v1.1.0",
+        body: "notes",
+        isPrerelease: false,
+        isDraft: false,
+        assets: [
+          {
+            name: "app.tgz",
+            url: "https://github.com/testuser/repo/releases/download/v1.1.0/app.tgz",
+            size: 123,
+            contentType: "application/gzip",
+          },
+        ],
+        repository: { owner: "testuser", name: "repo", visibility: "PUBLIC" },
+      },
+    ]);
+  });
+
+  it("collects repositories created within the range including their README", async () => {
+    createdRepoNodes.push(
+      {
+        owner: { login: "testuser" },
+        name: "new-repo",
+        visibility: "PUBLIC",
+        url: "https://github.com/testuser/new-repo",
+        description: "desc",
+        createdAt: "2024-01-08T00:00:00Z",
+        isFork: false,
+        object: { text: "# readme" },
+      },
+      {
+        owner: { login: "testuser" },
+        name: "old-repo",
+        visibility: "PUBLIC",
+        url: "https://github.com/testuser/old-repo",
+        description: null,
+        createdAt: "2023-01-01T00:00:00Z",
+        isFork: false,
+        object: null,
+      },
+    );
+
+    const events = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "Repository",
+    );
+    expect(events).toEqual([
+      {
+        type: "Repository",
+        createdAt: "2024-01-08T00:00:00Z",
+        url: "https://github.com/testuser/new-repo",
+        description: "desc",
+        isFork: false,
+        readme: "# readme",
+        repository: { owner: "testuser", name: "new-repo", visibility: "PUBLIC" },
+      },
+    ]);
+  });
+
+  it("collects wiki page edits from the events feed", async () => {
+    restResponsesByPath.set("/users/testuser/events", [
+      {
+        type: "GollumEvent",
+        public: true,
+        created_at: "2024-01-06T00:00:00Z",
+        repo: { name: "owner/repo" },
+        payload: {
+          pages: [
+            {
+              page_name: "Home",
+              title: "Home",
+              action: "edited",
+              html_url: "https://github.com/owner/repo/wiki/Home",
+            },
+          ],
+        },
+      },
+      {
+        type: "PushEvent",
+        public: true,
+        created_at: "2024-01-06T01:00:00Z",
+        repo: { name: "owner/repo" },
+        payload: {},
+      },
+      {
+        type: "GollumEvent",
+        public: true,
+        created_at: "2023-12-01T00:00:00Z",
+        repo: { name: "owner/repo" },
+        payload: {
+          pages: [
+            {
+              page_name: "Old",
+              title: "Old",
+              action: "created",
+              html_url: "https://github.com/owner/repo/wiki/Old",
+            },
+          ],
+        },
+      },
+    ]);
+
+    const events = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "WikiPageEdit",
+    );
+    expect(events).toEqual([
+      {
+        type: "WikiPageEdit",
+        createdAt: "2024-01-06T00:00:00Z",
+        pageTitle: "Home",
+        action: "edited",
+        url: "https://github.com/owner/repo/wiki/Home",
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+    ]);
+  });
+
+  it("emits each commit once with every branch it was seen on with --branches all", async () => {
+    contributionRepos.push(repoNode);
+    branchRefNodes.push({ name: "main" }, { name: "feature" });
+    const shared = {
+      oid: "aaa",
+      message: "shared commit",
+      url: "https://github.com/owner/repo/commit/aaa",
+      committedDate: "2024-01-05T00:00:00Z",
+      author: { user: { login: "testuser" } },
+    };
+    const featureOnly = {
+      oid: "bbb",
+      message: "feature-only commit",
+      url: "https://github.com/owner/repo/commit/bbb",
+      committedDate: "2024-01-06T00:00:00Z",
+      author: { user: { login: "testuser" } },
+    };
+    branchHistoryByRef.set("refs/heads/main", [shared]);
+    branchHistoryByRef.set("refs/heads/feature", [shared, featureOnly]);
+
+    const events = (await makeService({ branches: "all" }).fetchAllEvents()).filter(
+      (event) => event.type === "Commit",
+    );
+    expect(events).toEqual([
+      {
+        type: "Commit",
+        createdAt: "2024-01-05T00:00:00Z",
+        message: "shared commit",
+        url: "https://github.com/owner/repo/commit/aaa",
+        oid: "aaa",
+        branches: ["main", "feature"],
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+      {
+        type: "Commit",
+        createdAt: "2024-01-06T00:00:00Z",
+        message: "feature-only commit",
+        url: "https://github.com/owner/repo/commit/bbb",
+        oid: "bbb",
+        branches: ["feature"],
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+    ]);
+  });
+
+  it("attaches per-file diffs to commits with --commit-diff", async () => {
+    contributionRepos.push(repoNode);
+    defaultBranchHistoryNodes.push({
+      oid: "abc",
+      message: "commit with diff",
+      url: "https://github.com/owner/repo/commit/abc",
+      committedDate: "2024-01-05T00:00:00Z",
+      author: { user: { login: "testuser" } },
+    });
+    restResponsesByPath.set("/repos/owner/repo/commits/abc", {
+      files: [
+        {
+          filename: "src/secret.ts",
+          status: "added",
+          additions: 1,
+          deletions: 0,
+          patch: "+const key = 'x';",
+        },
+      ],
+    });
+
+    const events = (await makeService({ commitDiff: true }).fetchAllEvents()).filter(
+      (event) => event.type === "Commit",
+    );
+    expect(events).toEqual([
+      {
+        type: "Commit",
+        createdAt: "2024-01-05T00:00:00Z",
+        message: "commit with diff",
+        url: "https://github.com/owner/repo/commit/abc",
+        oid: "abc",
+        branches: ["main"],
+        diff: [
+          {
+            filename: "src/secret.ts",
+            status: "added",
+            additions: 1,
+            deletions: 0,
+            patch: "+const key = 'x';",
+          },
+        ],
+        repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
+      },
+    ]);
+    expect(restCalls).toContain("/repos/owner/repo/commits/abc");
+  });
+
+  it("omits diffs and uses the default branch without the new flags", async () => {
+    contributionRepos.push(repoNode);
+    defaultBranchHistoryNodes.push({
+      oid: "abc",
+      message: "plain commit",
+      url: "https://github.com/owner/repo/commit/abc",
+      committedDate: "2024-01-05T00:00:00Z",
+      author: { user: { login: "testuser" } },
+    });
+
+    const events = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "Commit",
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).not.toHaveProperty("diff");
+    expect(events[0]).toMatchObject({ branches: ["main"] });
+    expect(restCalls.filter((path) => path.startsWith("/repos/"))).toEqual([]);
+  });
+
+  it("attaches edit history to issue comments that were edited", async () => {
+    issueCommentSearchNodes.push({
+      id: "ISSUE_NODE_ID",
+      title: "Issue",
+      url: "https://github.com/owner/repo/issues/1",
+      createdAt: "2024-01-02T00:00:00Z",
+      repository: { owner: { login: "owner" }, name: "repo", visibility: "PUBLIC" },
+      comments: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            body: "edited comment",
+            url: "https://github.com/owner/repo/issues/1#issuecomment-1",
+            createdAt: "2024-01-05T12:00:00Z",
+            author: { login: "testuser" },
+            userContentEdits: {
+              nodes: [
+                { editedAt: "2024-01-05T13:00:00Z", deletedAt: null, diff: "original wording" },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const events = (await makeService().fetchAllEvents()).filter(
+      (event) => event.type === "IssueComment",
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      editHistory: [
+        { editedAt: "2024-01-05T13:00:00Z", deletedAt: null, diff: "original wording" },
+      ],
+    });
   });
 });
 

--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -25,6 +25,7 @@ const {
   pushedRepoNodes,
   restCalls,
   restResponsesByPath,
+  restFailureQueue,
 } = vi.hoisted(() => ({
   calls: [] as Array<{ query: string; variables: Record<string, unknown> }>,
   issueCommentSearchNodes: [] as unknown[],
@@ -48,6 +49,8 @@ const {
   pushedRepoNodes: [] as unknown[],
   restCalls: [] as string[],
   restResponsesByPath: new Map<string, unknown>(),
+  // Each entry makes the next REST call fail with the given status and body.
+  restFailureQueue: [] as { status: number; body: unknown }[],
 }));
 
 // Mock @octokit/graphql with a stub that returns empty-but-valid shapes for
@@ -190,6 +193,16 @@ vi.stubGlobal(
   vi.fn((url: string | URL) => {
     const fullPath = String(url).replace("https://api.github.com", "");
     restCalls.push(fullPath);
+    const failure = restFailureQueue.shift();
+    if (failure) {
+      return Promise.resolve({
+        ok: false,
+        status: failure.status,
+        headers: new Headers(),
+        text: () => Promise.resolve(JSON.stringify(failure.body)),
+        json: () => Promise.resolve(failure.body),
+      } as unknown as Response);
+    }
     const preset =
       restResponsesByPath.get(fullPath) ?? restResponsesByPath.get(fullPath.split("?")[0] ?? "");
     const body = preset ?? (fullPath.startsWith("/users/") ? [] : { files: [] });
@@ -221,6 +234,7 @@ beforeEach(() => {
   pushedRepoNodes.length = 0;
   restCalls.length = 0;
   restResponsesByPath.clear();
+  restFailureQueue.length = 0;
 });
 
 const makeService = (params?: {
@@ -862,6 +876,14 @@ describe("username override", () => {
   });
 });
 
+const fileEntry = (index: number) => ({
+  filename: `file-${String(index)}.ts`,
+  status: "modified",
+  additions: 1,
+  deletions: 0,
+  patch: "+x",
+});
+
 describe("audit event collection", () => {
   const repoNode = { owner: { login: "owner" }, name: "repo", visibility: "PUBLIC" };
 
@@ -911,6 +933,21 @@ describe("audit event collection", () => {
       (event) => event.type === "Gist",
     );
     expect(privateEvents.map((event) => event.repository.name)).toEqual(["bbb222"]);
+  });
+
+  it("tolerates a null gist files list", async () => {
+    gistNodes.push({
+      name: "ddd444",
+      description: null,
+      url: "https://gist.github.com/testuser/ddd444",
+      createdAt: "2024-01-05T00:00:00Z",
+      isPublic: true,
+      files: null,
+    });
+
+    const events = (await makeService().fetchAllEvents()).filter((event) => event.type === "Gist");
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type === "Gist" && events[0].files).toEqual([]);
   });
 
   it("warns and skips gists when the token lacks gist access", async () => {
@@ -980,6 +1017,7 @@ describe("audit event collection", () => {
             tagName: "v1.1.0",
             url: "https://github.com/testuser/repo/releases/tag/v1.1.0",
             createdAt: "2024-01-10T00:00:00Z",
+            publishedAt: null,
             description: "notes",
             isPrerelease: false,
             isDraft: false,
@@ -996,10 +1034,23 @@ describe("audit event collection", () => {
             },
           },
           {
+            name: "published later",
+            tagName: "v1.0.2",
+            url: "https://github.com/testuser/repo/releases/tag/v1.0.2",
+            createdAt: "2024-01-09T12:00:00Z",
+            publishedAt: "2024-01-11T00:00:00Z",
+            description: null,
+            isPrerelease: false,
+            isDraft: false,
+            author: { login: "testuser" },
+            releaseAssets: { nodes: [] },
+          },
+          {
             name: "by someone else",
             tagName: "v1.0.1",
             url: "https://github.com/testuser/repo/releases/tag/v1.0.1",
             createdAt: "2024-01-09T00:00:00Z",
+            publishedAt: "2024-01-09T00:00:00Z",
             description: null,
             isPrerelease: false,
             isDraft: false,
@@ -1031,6 +1082,18 @@ describe("audit event collection", () => {
             contentType: "application/gzip",
           },
         ],
+        repository: { owner: "testuser", name: "repo", visibility: "PUBLIC" },
+      },
+      {
+        type: "Release",
+        createdAt: "2024-01-11T00:00:00Z",
+        title: "published later",
+        tagName: "v1.0.2",
+        url: "https://github.com/testuser/repo/releases/tag/v1.0.2",
+        body: null,
+        isPrerelease: false,
+        isDraft: false,
+        assets: [],
         repository: { owner: "testuser", name: "repo", visibility: "PUBLIC" },
       },
     ]);
@@ -1223,7 +1286,123 @@ describe("audit event collection", () => {
         repository: { owner: "owner", name: "repo", visibility: "PUBLIC" },
       },
     ]);
-    expect(restCalls).toContain("/repos/owner/repo/commits/abc");
+    expect(restCalls).toContain("/repos/owner/repo/commits/abc?page=1");
+  });
+
+  it("pages commit diffs past the 300-file REST cap", async () => {
+    contributionRepos.push(repoNode);
+    defaultBranchHistoryNodes.push({
+      oid: "big",
+      message: "vendored commit",
+      url: "https://github.com/owner/repo/commit/big",
+      committedDate: "2024-01-05T00:00:00Z",
+      author: { user: { login: "testuser" } },
+    });
+    restResponsesByPath.set("/repos/owner/repo/commits/big?page=1", {
+      files: Array.from({ length: 300 }, (_, index) => fileEntry(index)),
+    });
+    restResponsesByPath.set("/repos/owner/repo/commits/big?page=2", {
+      files: [fileEntry(300)],
+    });
+
+    const events = (await makeService({ commitDiff: true }).fetchAllEvents()).filter(
+      (event) => event.type === "Commit",
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type === "Commit" && events[0].diff?.length).toBe(301);
+  });
+
+  it("adds own repositories pushed within the range with --branches all", async () => {
+    pushedRepoNodes.push(
+      // Never-pushed repositories must be skipped, not treated as an early stop.
+      { owner: { login: "testuser" }, name: "never-pushed", visibility: "PUBLIC", pushedAt: null },
+      {
+        owner: { login: "testuser" },
+        name: "pushed-repo",
+        visibility: "PUBLIC",
+        pushedAt: "2024-01-10T00:00:00Z",
+      },
+      {
+        owner: { login: "testuser" },
+        name: "private-repo",
+        visibility: "PRIVATE",
+        pushedAt: "2024-01-09T00:00:00Z",
+      },
+      {
+        owner: { login: "testuser" },
+        name: "old-repo",
+        visibility: "PUBLIC",
+        pushedAt: "2023-01-01T00:00:00Z",
+      },
+    );
+    branchRefNodes.push({ name: "main" });
+    branchHistoryByRef.set("refs/heads/main", [
+      {
+        oid: "ccc",
+        message: "branch commit",
+        url: "https://github.com/testuser/pushed-repo/commit/ccc",
+        committedDate: "2024-01-11T00:00:00Z",
+        author: { user: { login: "testuser" } },
+      },
+    ]);
+
+    const events = (await makeService({ branches: "all" }).fetchAllEvents()).filter(
+      (event) => event.type === "Commit",
+    );
+    // Only the public repository pushed within the range is scanned: the
+    // private one is filtered by --visibility and the old one stops the scan.
+    expect(events.map((event) => event.repository.name)).toEqual(["pushed-repo"]);
+  });
+
+  it("warns when the range predates the events feed coverage", async () => {
+    const warnings: string[] = [];
+    await makeService({ onWarning: (message) => warnings.push(message) }).fetchAllEvents();
+    expect(warnings.some((message) => message.includes("most recent 90 days"))).toBe(true);
+  });
+
+  it("warns when the capped events feed does not reach --since", async () => {
+    const now = Date.now();
+    const feedItem = {
+      type: "PushEvent",
+      public: true,
+      created_at: new Date(now - 60 * 60 * 1000).toISOString(),
+      repo: { name: "owner/repo" },
+      payload: {},
+    };
+    for (const page of [1, 2, 3]) {
+      restResponsesByPath.set(
+        `/users/testuser/events?per_page=100&page=${String(page)}`,
+        Array.from({ length: 100 }, () => feedItem),
+      );
+    }
+
+    const warnings: string[] = [];
+    await makeService({
+      since: new Date(now - 7 * 24 * 60 * 60 * 1000),
+      until: new Date(now),
+      onWarning: (message) => warnings.push(message),
+    }).fetchAllEvents();
+
+    expect(warnings.some((message) => message.includes("did not reach --since"))).toBe(true);
+    expect(warnings.some((message) => message.includes("most recent 90 days"))).toBe(false);
+  });
+
+  it("retries REST secondary rate limits using the response body message", async () => {
+    restFailureQueue.push({
+      status: 403,
+      body: { message: "You have exceeded a secondary rate limit. Please wait." },
+    });
+
+    const warnings: string[] = [];
+    const events = await makeService({
+      onWarning: (message) => warnings.push(message),
+    }).fetchAllEvents();
+
+    expect(events).toEqual([]);
+    expect(restCalls.filter((path) => path.includes("/events")).length).toBeGreaterThanOrEqual(2);
+    expect(
+      warnings.some((message) => message.includes("retrying") && message.includes("rate limit")),
+    ).toBe(true);
   });
 
   it("omits diffs and uses the default branch without the new flags", async () => {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,25 +1,39 @@
 import { graphql } from "@octokit/graphql";
 
-import type { Visibility } from "../types/cli.js";
-import type { GitHubEvent } from "../types/events.js";
+import type { Branches, Visibility } from "../types/cli.js";
+import type { CommitDiffFile, CommitEvent, ContentEdit, GitHubEvent } from "../types/events.js";
 import type {
+  BranchCommitHistoryResponse,
+  BranchRefsResponse,
   CommentNode,
   CommentsConnection,
   CommentsPageResponse,
+  CommitCommentsResponse,
+  CommitHistoryNode,
   CommitHistoryResponse,
   ContributionsCollectionResponse,
+  CreatedRepositoriesResponse,
   DiscussionNode,
   DiscussionWithCommentsNode,
+  GistsResponse,
   IssueNode,
   IssueWithCommentsNode,
   PullRequestNode,
   PullRequestWithCommentsNode,
   PullRequestWithReviewsNode,
+  PushedRepositoriesResponse,
+  ReleasesConnection,
+  ReleasesPageResponse,
+  RepositoriesWithReleasesResponse,
   RepositoryVisibility,
+  RepositoryWithReleasesNode,
+  RestCommitDetail,
+  RestUserEvent,
   ReviewNode,
   ReviewsConnection,
   ReviewsPageResponse,
   SearchResponse,
+  UserContentEditsConnection,
   UserIdResponse,
   ViewerResponse,
 } from "../types/github-api.js";
@@ -34,11 +48,16 @@ import {
 import { formatError } from "../utils/error.js";
 import { GITHUB_LOGIN_PATTERN } from "../utils/github-login.js";
 import {
+  BRANCH_COMMIT_HISTORY_QUERY,
+  BRANCH_REFS_QUERY,
+  COMMIT_COMMENTS_QUERY,
   COMMIT_HISTORY_QUERY,
   CONTRIBUTIONS_COLLECTION_QUERY,
+  CREATED_REPOSITORIES_QUERY,
   DISCUSSION_COMMENT_SEARCH_QUERY,
   DISCUSSION_COMMENTS_PAGE_QUERY,
   DISCUSSION_SEARCH_QUERY,
+  GISTS_QUERY,
   ISSUE_COMMENT_SEARCH_QUERY,
   ISSUE_COMMENTS_PAGE_QUERY,
   ISSUE_SEARCH_QUERY,
@@ -46,6 +65,9 @@ import {
   PULL_REQUEST_COMMENTS_PAGE_QUERY,
   PULL_REQUEST_REVIEW_SEARCH_QUERY,
   PULL_REQUEST_SEARCH_QUERY,
+  PUSHED_REPOSITORIES_QUERY,
+  RELEASES_PAGE_QUERY,
+  REPOSITORIES_WITH_RELEASES_QUERY,
   REVIEW_COMMENTS_PAGE_QUERY,
   REVIEWS_PAGE_QUERY,
   USER_ID_QUERY,
@@ -59,12 +81,23 @@ interface GitHubServiceParams {
   since: Date;
   until: Date;
   visibility: Visibility;
+  /** Collect commits from the default branch only, or from every branch. */
+  branches?: Branches | undefined;
+  /** Attach per-file diffs to Commit events (one extra REST call per commit). */
+  commitDiff?: boolean | undefined;
   onWarning?: (message: string) => void;
   retry?: {
     maxRetries?: number;
     baseDelayMs?: number;
   };
 }
+
+const GITHUB_REST_BASE_URL = "https://api.github.com";
+
+// The events feed behind wiki-edit collection is capped by GitHub.
+const EVENTS_FEED_MAX_PAGES = 3;
+const EVENTS_FEED_PAGE_SIZE = 100;
+const EVENTS_FEED_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
 // GitHub's Search API never returns more than 1,000 results per query.
 const SEARCH_RESULT_CAP = 1000;
@@ -87,10 +120,37 @@ interface GitHubApiErrorShape {
   errors?: { type?: string }[];
 }
 
+// Maps a comment's prior revisions to the event's editHistory field;
+// undefined (field omitted) when the comment was never edited.
+function toEditHistory(
+  edits: UserContentEditsConnection | null | undefined,
+): ContentEdit[] | undefined {
+  const nodes = edits?.nodes ?? [];
+  if (nodes.length === 0) return undefined;
+  return nodes.map((edit) => ({
+    editedAt: edit.editedAt,
+    deletedAt: edit.deletedAt,
+    diff: edit.diff,
+  }));
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+// GraphQL errors raised when the token cannot access a resource at all, e.g.
+// a fine-grained token without the Gists read permission.
+function isTokenAccessError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const err = error as GitHubApiErrorShape;
+  return (
+    err.errors?.some(
+      (graphqlError) =>
+        graphqlError.type === "FORBIDDEN" || graphqlError.type === "INSUFFICIENT_SCOPES",
+    ) ?? false
+  );
 }
 
 function isRetryableError(error: unknown): boolean {
@@ -125,6 +185,7 @@ export function computeRetryDelayMs(params: {
 
 export class GitHubService {
   private readonly graphqlWithAuth: typeof graphql;
+  private readonly token: string;
   private readonly username: string | undefined;
   // Caches the id lookup, which runs both as the up-front --user existence
   // check and for the commit history author filter.
@@ -132,6 +193,8 @@ export class GitHubService {
   private readonly since: Date;
   private readonly until: Date;
   private readonly visibility: Visibility;
+  private readonly branches: Branches;
+  private readonly commitDiff: boolean;
   private readonly onWarning: (message: string) => void;
   private readonly maxRetries: number;
   private readonly retryBaseDelayMs: number;
@@ -140,10 +203,13 @@ export class GitHubService {
     this.graphqlWithAuth = graphql.defaults({
       headers: { authorization: `token ${params.token}` },
     });
+    this.token = params.token;
     this.username = params.username;
     this.since = params.since;
     this.until = params.until;
     this.visibility = params.visibility;
+    this.branches = params.branches ?? "default";
+    this.commitDiff = params.commitDiff ?? false;
     this.onWarning = params.onWarning ?? (() => {});
     this.maxRetries = params.retry?.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.retryBaseDelayMs = params.retry?.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
@@ -190,6 +256,11 @@ export class GitHubService {
         run: () => this.fetchPullRequestReviewComments(username),
       },
       { label: "commits", run: () => this.fetchCommits(username) },
+      { label: "commit comments", run: () => this.fetchCommitComments(username) },
+      { label: "gists", run: () => this.fetchGists(username) },
+      { label: "releases", run: () => this.fetchReleases(username) },
+      { label: "repositories", run: () => this.fetchCreatedRepositories(username) },
+      { label: "wiki page edits", run: () => this.fetchWikiPageEdits(username) },
     ];
 
     const events: GitHubEvent[] = [];
@@ -205,13 +276,13 @@ export class GitHubService {
     return events;
   }
 
-  // Executes a GraphQL request, retrying transient failures (rate limits and
-  // gateway errors) with the server-suggested delay when available, falling
-  // back to exponential backoff.
-  private async execute<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+  // Runs a request, retrying transient failures (rate limits and gateway
+  // errors) with the server-suggested delay when available, falling back to
+  // exponential backoff.
+  private async withRetry<T>(run: () => Promise<T>): Promise<T> {
     for (let attempt = 0; ; attempt++) {
       try {
-        return await this.graphqlWithAuth<T>(query, variables ?? {});
+        return await run();
       } catch (error) {
         if (attempt >= this.maxRetries || !isRetryableError(error)) throw error;
         const delayMs = computeRetryDelayMs({
@@ -225,6 +296,37 @@ export class GitHubService {
         await sleep(delayMs);
       }
     }
+  }
+
+  private async execute<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+    return this.withRetry(() => this.graphqlWithAuth<T>(query, variables ?? {}));
+  }
+
+  // Minimal REST client for the endpoints the GraphQL API does not cover
+  // (commit diffs and the user events feed). Reuses the GraphQL retry policy:
+  // the thrown error carries `status` and `headers` in the same shape.
+  private async executeRest<T>(path: string): Promise<T> {
+    return this.withRetry(async () => {
+      const response = await fetch(`${GITHUB_REST_BASE_URL}${path}`, {
+        headers: {
+          authorization: `token ${this.token}`,
+          accept: "application/vnd.github+json",
+          "user-agent": "ghactivities",
+          "x-github-api-version": "2022-11-28",
+        },
+      });
+      if (!response.ok) {
+        const error = new Error(
+          `GitHub REST API request to ${path} failed with status ${String(response.status)}`,
+        );
+        Object.assign(error, {
+          status: response.status,
+          headers: Object.fromEntries(response.headers.entries()),
+        });
+        throw error;
+      }
+      return (await response.json()) as T;
+    });
   }
 
   private async getViewerLogin(): Promise<string> {
@@ -414,6 +516,7 @@ export class GitHubService {
       });
       for (const comment of comments) {
         if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
+          const editHistory = toEditHistory(comment.userContentEdits);
           events.push({
             type: "IssueComment",
             createdAt: comment.createdAt,
@@ -426,6 +529,7 @@ export class GitHubService {
               name: node.repository.name,
               visibility: node.repository.visibility,
             },
+            ...(editHistory ? { editHistory } : {}),
           });
         }
       }
@@ -480,6 +584,7 @@ export class GitHubService {
       });
       for (const comment of comments) {
         if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
+          const editHistory = toEditHistory(comment.userContentEdits);
           events.push({
             type: "DiscussionComment",
             createdAt: comment.createdAt,
@@ -492,6 +597,7 @@ export class GitHubService {
               name: node.repository.name,
               visibility: node.repository.visibility,
             },
+            ...(editHistory ? { editHistory } : {}),
           });
         }
       }
@@ -546,6 +652,7 @@ export class GitHubService {
       });
       for (const comment of comments) {
         if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
+          const editHistory = toEditHistory(comment.userContentEdits);
           events.push({
             type: "PullRequestComment",
             createdAt: comment.createdAt,
@@ -558,6 +665,7 @@ export class GitHubService {
               name: node.repository.name,
               visibility: node.repository.visibility,
             },
+            ...(editHistory ? { editHistory } : {}),
           });
         }
       }
@@ -626,6 +734,7 @@ export class GitHubService {
         // A review drafted earlier counts from its submission time.
         const reviewTimestamp = review.submittedAt ?? review.createdAt;
         if (review.body !== "" && this.isWithinDateRange(reviewTimestamp)) {
+          const editHistory = toEditHistory(review.userContentEdits);
           events.push({
             type: "PullRequestReviewComment",
             createdAt: reviewTimestamp,
@@ -634,6 +743,7 @@ export class GitHubService {
             body: review.body,
             url: review.url,
             repository,
+            ...(editHistory ? { editHistory } : {}),
           });
         }
 
@@ -644,6 +754,7 @@ export class GitHubService {
         });
         for (const comment of comments) {
           if (comment.author?.login === username && this.isWithinDateRange(comment.createdAt)) {
+            const editHistory = toEditHistory(comment.userContentEdits);
             events.push({
               type: "PullRequestReviewComment",
               createdAt: comment.createdAt,
@@ -652,6 +763,7 @@ export class GitHubService {
               body: comment.body,
               url: comment.url,
               repository,
+              ...(editHistory ? { editHistory } : {}),
             });
           }
         }
@@ -661,15 +773,19 @@ export class GitHubService {
     return events;
   }
 
-  private async fetchCommits(username: string): Promise<GitHubEvent[]> {
-    const events: GitHubEvent[] = [];
-    const authorId = await this.getUserId(username);
+  // Discovers repositories to scan for commits. contributionsCollection only
+  // counts default-branch (and gh-pages) commits, so with --branches all the
+  // user's own repositories pushed within the range are added on top; branches
+  // of unowned repositories without default-branch contributions can still be
+  // missed (documented in the README).
+  private async discoverCommitRepositories(
+    username: string,
+  ): Promise<Map<string, RepositoryVisibility>> {
+    const repoMap = new Map<string, RepositoryVisibility>();
     const periods = splitDateRangeIntoYearPeriods({
       since: this.since,
       until: this.until,
     });
-
-    const repoMap = new Map<string, RepositoryVisibility>();
 
     for (const period of periods) {
       const response = await this.execute<ContributionsCollectionResponse>(
@@ -689,46 +805,487 @@ export class GitHubService {
       }
     }
 
-    for (const [repoKey, visibility] of repoMap) {
-      const [owner, name] = repoKey.split("/") as [string, string];
-      let cursor: string | null = null;
-
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        const response: CommitHistoryResponse = await this.execute<CommitHistoryResponse>(
-          COMMIT_HISTORY_QUERY,
+    if (this.branches === "all") {
+      let after: string | null = null;
+      let hasNext = true;
+      while (hasNext) {
+        const response: PushedRepositoriesResponse = await this.execute<PushedRepositoriesResponse>(
+          PUSHED_REPOSITORIES_QUERY,
           {
-            owner,
-            name,
-            since: this.since.toISOString(),
-            until: this.until.toISOString(),
-            first: 100,
-            after: cursor,
-            authorId,
+            login: username,
+            first: 50,
+            after,
           },
         );
+        const connection = response.user?.repositories;
+        if (!connection) break;
+        let reachedOlder = false;
+        for (const node of connection.nodes) {
+          if (node.pushedAt === null || new Date(node.pushedAt) < this.since) {
+            reachedOlder = true;
+            break;
+          }
+          if (this.matchesVisibility(node.visibility)) {
+            repoMap.set(`${node.owner.login}/${node.name}`, node.visibility);
+          }
+        }
+        hasNext =
+          !reachedOlder &&
+          connection.pageInfo.hasNextPage &&
+          connection.pageInfo.endCursor !== null;
+        after = connection.pageInfo.endCursor;
+      }
+    }
 
+    return repoMap;
+  }
+
+  // Pages one branch's commit history. The history connection shape is shared
+  // by the default-branch and per-ref queries.
+  private async collectBranchHistory(params: {
+    owner: string;
+    name: string;
+    branch: string | null;
+    authorId: string;
+  }): Promise<{ branch: string; nodes: CommitHistoryNode[] } | null> {
+    const nodes: CommitHistoryNode[] = [];
+    let branchName = params.branch;
+    let cursor: string | null = null;
+    let hasNext = true;
+
+    while (hasNext) {
+      const variables = {
+        owner: params.owner,
+        name: params.name,
+        since: this.since.toISOString(),
+        until: this.until.toISOString(),
+        first: 100,
+        after: cursor,
+        authorId: params.authorId,
+      };
+
+      let history: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: CommitHistoryNode[];
+      };
+      if (params.branch === null) {
+        const response: CommitHistoryResponse = await this.execute<CommitHistoryResponse>(
+          COMMIT_HISTORY_QUERY,
+          variables,
+        );
         const ref = response.repository.defaultBranchRef;
-        if (!ref) break;
+        if (!ref) return null;
+        branchName = ref.name;
+        history = ref.target.history;
+      } else {
+        const response: BranchCommitHistoryResponse =
+          await this.execute<BranchCommitHistoryResponse>(BRANCH_COMMIT_HISTORY_QUERY, {
+            ...variables,
+            qualifiedName: `refs/heads/${params.branch}`,
+          });
+        const target = response.repository?.ref?.target;
+        if (!target?.history) return null;
+        history = target.history;
+      }
 
-        for (const node of ref.target.history.nodes) {
+      nodes.push(...history.nodes);
+      hasNext = history.pageInfo.hasNextPage && history.pageInfo.endCursor !== null;
+      cursor = history.pageInfo.endCursor;
+    }
+
+    return branchName === null ? null : { branch: branchName, nodes };
+  }
+
+  private async listBranches(params: { owner: string; name: string }): Promise<string[]> {
+    const branches: string[] = [];
+    let after: string | null = null;
+    let hasNext = true;
+    while (hasNext) {
+      const response: BranchRefsResponse = await this.execute<BranchRefsResponse>(
+        BRANCH_REFS_QUERY,
+        { owner: params.owner, name: params.name, first: 100, after },
+      );
+      const refs = response.repository?.refs;
+      if (!refs) break;
+      branches.push(...refs.nodes.map((node) => node.name));
+      hasNext = refs.pageInfo.hasNextPage && refs.pageInfo.endCursor !== null;
+      after = refs.pageInfo.endCursor;
+    }
+    return branches;
+  }
+
+  private async fetchCommitDiff(params: {
+    owner: string;
+    name: string;
+    oid: string;
+  }): Promise<CommitDiffFile[]> {
+    const detail = await this.executeRest<RestCommitDetail>(
+      `/repos/${params.owner}/${params.name}/commits/${params.oid}`,
+    );
+    return (detail.files ?? []).map((file) => ({
+      filename: file.filename,
+      status: file.status,
+      additions: file.additions,
+      deletions: file.deletions,
+      patch: file.patch ?? null,
+    }));
+  }
+
+  private async fetchCommits(username: string): Promise<GitHubEvent[]> {
+    const events: GitHubEvent[] = [];
+    const authorId = await this.getUserId(username);
+    const repoMap = await this.discoverCommitRepositories(username);
+
+    for (const [repoKey, visibility] of repoMap) {
+      const [owner, name] = repoKey.split("/") as [string, string];
+
+      // With --branches all, the same commit is usually reachable from several
+      // branches; it is emitted once, listing every branch it was seen on.
+      const commitsByOid = new Map<string, { node: CommitHistoryNode; branches: string[] }>();
+      const branchNames =
+        this.branches === "all" ? await this.listBranches({ owner, name }) : [null];
+
+      for (const branch of branchNames) {
+        const result = await this.collectBranchHistory({ owner, name, branch, authorId });
+        if (!result) continue;
+        for (const node of result.nodes) {
+          const entry = commitsByOid.get(node.oid);
+          if (entry) {
+            entry.branches.push(result.branch);
+          } else {
+            commitsByOid.set(node.oid, { node, branches: [result.branch] });
+          }
+        }
+      }
+
+      for (const { node, branches } of commitsByOid.values()) {
+        const event: CommitEvent = {
+          type: "Commit",
+          createdAt: node.committedDate,
+          message: node.message,
+          url: node.url,
+          oid: node.oid,
+          branches,
+          repository: {
+            owner,
+            name,
+            visibility,
+          },
+        };
+        if (this.commitDiff) {
+          event.diff = await this.fetchCommitDiff({ owner, name, oid: node.oid });
+        }
+        events.push(event);
+      }
+    }
+
+    return events;
+  }
+
+  private async fetchCommitComments(username: string): Promise<GitHubEvent[]> {
+    const events: GitHubEvent[] = [];
+    let after: string | null = null;
+    let hasNext = true;
+
+    // The commitComments connection has no orderBy, so every page is scanned
+    // and filtered by the date range.
+    while (hasNext) {
+      const response: CommitCommentsResponse = await this.execute<CommitCommentsResponse>(
+        COMMIT_COMMENTS_QUERY,
+        { login: username, first: 100, after },
+      );
+      const connection = response.user?.commitComments;
+      if (!connection) break;
+
+      for (const node of connection.nodes) {
+        if (!this.matchesVisibility(node.repository.visibility)) continue;
+        if (!this.isWithinDateRange(node.createdAt)) continue;
+        const editHistory = toEditHistory(node.userContentEdits);
+        events.push({
+          type: "CommitComment",
+          createdAt: node.createdAt,
+          body: node.body,
+          url: node.url,
+          commitOid: node.commit?.oid ?? null,
+          repository: {
+            owner: node.repository.owner.login,
+            name: node.repository.name,
+            visibility: node.repository.visibility,
+          },
+          ...(editHistory ? { editHistory } : {}),
+        });
+      }
+
+      hasNext = connection.pageInfo.hasNextPage && connection.pageInfo.endCursor !== null;
+      after = connection.pageInfo.endCursor;
+    }
+
+    return events;
+  }
+
+  // Gists need their own token permission (the "gist" scope, or Gists read
+  // access on fine-grained tokens). A token without it should not fail the
+  // whole collection run, so the fetch degrades to a warning.
+  private async fetchGists(username: string): Promise<GitHubEvent[]> {
+    try {
+      return await this.collectGists(username);
+    } catch (error) {
+      if (isTokenAccessError(error)) {
+        this.onWarning(
+          `Gists could not be collected (${formatError(error)}); grant the token gist read access to include them.`,
+        );
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  private async collectGists(username: string): Promise<GitHubEvent[]> {
+    const events: GitHubEvent[] = [];
+    let after: string | null = null;
+    let hasNext = true;
+
+    while (hasNext) {
+      const response: GistsResponse = await this.execute<GistsResponse>(GISTS_QUERY, {
+        login: username,
+        first: 100,
+        after,
+      });
+      const connection = response.user?.gists;
+      if (!connection) break;
+
+      // Newest first: everything after the first gist older than --since is
+      // out of range too.
+      let reachedOlder = false;
+      for (const node of connection.nodes) {
+        if (new Date(node.createdAt) < this.since) {
+          reachedOlder = true;
+          break;
+        }
+        // Secret gists group with private repositories.
+        const visibility: RepositoryVisibility = node.isPublic ? "PUBLIC" : "PRIVATE";
+        if (!this.matchesVisibility(visibility)) continue;
+        if (!this.isWithinDateRange(node.createdAt)) continue;
+        events.push({
+          type: "Gist",
+          createdAt: node.createdAt,
+          description: node.description,
+          url: node.url,
+          files: node.files.map((file) => ({
+            name: file.name,
+            size: file.size,
+            text: file.text,
+          })),
+          repository: {
+            owner: username,
+            name: node.name,
+            visibility,
+          },
+        });
+      }
+
+      hasNext =
+        !reachedOlder && connection.pageInfo.hasNextPage && connection.pageInfo.endCursor !== null;
+      after = connection.pageInfo.endCursor;
+    }
+
+    return events;
+  }
+
+  // Collects the in-range releases of one repository, paging past the first
+  // 25 only while the (newest-first) scan is still inside the date range.
+  private async collectRepositoryReleases(params: {
+    repo: RepositoryWithReleasesNode;
+    username: string;
+  }): Promise<GitHubEvent[]> {
+    const { repo, username } = params;
+    if (!this.matchesVisibility(repo.visibility)) return [];
+
+    const events: GitHubEvent[] = [];
+    let connection: ReleasesConnection = repo.releases;
+
+    for (;;) {
+      let reachedOlder = false;
+      for (const release of connection.nodes) {
+        if (new Date(release.createdAt) < this.since) {
+          reachedOlder = true;
+          break;
+        }
+        if (release.author?.login !== username) continue;
+        if (!this.isWithinDateRange(release.createdAt)) continue;
+        events.push({
+          type: "Release",
+          createdAt: release.createdAt,
+          title: release.name ?? release.tagName,
+          tagName: release.tagName,
+          url: release.url,
+          body: release.description,
+          isPrerelease: release.isPrerelease,
+          isDraft: release.isDraft,
+          assets: release.releaseAssets.nodes.map((asset) => ({
+            name: asset.name,
+            url: asset.downloadUrl,
+            size: asset.size,
+            contentType: asset.contentType,
+          })),
+          repository: {
+            owner: repo.owner.login,
+            name: repo.name,
+            visibility: repo.visibility,
+          },
+        });
+      }
+
+      if (reachedOlder || !connection.pageInfo.hasNextPage || !connection.pageInfo.endCursor) {
+        break;
+      }
+      const response: ReleasesPageResponse = await this.execute<ReleasesPageResponse>(
+        RELEASES_PAGE_QUERY,
+        {
+          owner: repo.owner.login,
+          name: repo.name,
+          first: 25,
+          after: connection.pageInfo.endCursor,
+        },
+      );
+      if (!response.repository) break;
+      connection = response.repository.releases;
+    }
+
+    return events;
+  }
+
+  // Releases are discovered by walking the user's own repositories; releases
+  // the user published in repositories they do not own are not collected
+  // (documented in the README).
+  private async fetchReleases(username: string): Promise<GitHubEvent[]> {
+    const events: GitHubEvent[] = [];
+    let after: string | null = null;
+    let hasNext = true;
+
+    while (hasNext) {
+      const response: RepositoriesWithReleasesResponse =
+        await this.execute<RepositoriesWithReleasesResponse>(REPOSITORIES_WITH_RELEASES_QUERY, {
+          login: username,
+          first: 50,
+          after,
+        });
+      const connection = response.user?.repositories;
+      if (!connection) break;
+
+      for (const repo of connection.nodes) {
+        events.push(...(await this.collectRepositoryReleases({ repo, username })));
+      }
+
+      hasNext = connection.pageInfo.hasNextPage && connection.pageInfo.endCursor !== null;
+      after = connection.pageInfo.endCursor;
+    }
+
+    return events;
+  }
+
+  private async fetchCreatedRepositories(username: string): Promise<GitHubEvent[]> {
+    const events: GitHubEvent[] = [];
+    let after: string | null = null;
+    let hasNext = true;
+
+    while (hasNext) {
+      const response: CreatedRepositoriesResponse = await this.execute<CreatedRepositoriesResponse>(
+        CREATED_REPOSITORIES_QUERY,
+        {
+          login: username,
+          first: 50,
+          after,
+        },
+      );
+      const connection = response.user?.repositories;
+      if (!connection) break;
+
+      // Newest first: stop at the first repository created before --since.
+      let reachedOlder = false;
+      for (const node of connection.nodes) {
+        if (new Date(node.createdAt) < this.since) {
+          reachedOlder = true;
+          break;
+        }
+        if (!this.matchesVisibility(node.visibility)) continue;
+        if (!this.isWithinDateRange(node.createdAt)) continue;
+        events.push({
+          type: "Repository",
+          createdAt: node.createdAt,
+          url: node.url,
+          description: node.description,
+          isFork: node.isFork,
+          readme: node.object?.text ?? null,
+          repository: {
+            owner: node.owner.login,
+            name: node.name,
+            visibility: node.visibility,
+          },
+        });
+      }
+
+      hasNext =
+        !reachedOlder && connection.pageInfo.hasNextPage && connection.pageInfo.endCursor !== null;
+      after = connection.pageInfo.endCursor;
+    }
+
+    return events;
+  }
+
+  // Wiki edits have no GraphQL or dedicated REST API; the user events feed is
+  // the only source, and GitHub caps it at the most recent 300 events within
+  // 90 days. A warning is emitted when that window cannot cover --since.
+  private async fetchWikiPageEdits(username: string): Promise<GitHubEvent[]> {
+    const events: GitHubEvent[] = [];
+
+    if (Date.now() - this.since.getTime() > EVENTS_FEED_MAX_AGE_MS) {
+      this.onWarning(
+        "Wiki page edits come from the GitHub events feed, which only covers the most recent 90 days; older wiki edits in the range are missing.",
+      );
+    }
+
+    let feedExhausted = false;
+    let oldestSeen: Date | null = null;
+
+    for (let page = 1; page <= EVENTS_FEED_MAX_PAGES; page++) {
+      const items = await this.executeRest<RestUserEvent[]>(
+        `/users/${username}/events?per_page=${String(EVENTS_FEED_PAGE_SIZE)}&page=${String(page)}`,
+      );
+
+      for (const item of items) {
+        const createdAt = new Date(item.created_at);
+        if (oldestSeen === null || createdAt < oldestSeen) oldestSeen = createdAt;
+        if (item.type !== "GollumEvent") continue;
+        if (!this.isWithinDateRange(item.created_at)) continue;
+        // The feed only distinguishes public from non-public.
+        const visibility: RepositoryVisibility = item.public ? "PUBLIC" : "PRIVATE";
+        if (!this.matchesVisibility(visibility)) continue;
+        const [owner, name] = item.repo.name.split("/") as [string, string];
+        for (const wikiPage of item.payload.pages ?? []) {
           events.push({
-            type: "Commit",
-            createdAt: node.committedDate,
-            message: node.message,
-            url: node.url,
-            oid: node.oid,
-            repository: {
-              owner,
-              name,
-              visibility,
-            },
+            type: "WikiPageEdit",
+            createdAt: item.created_at,
+            pageTitle: wikiPage.title,
+            action: wikiPage.action,
+            url: wikiPage.html_url,
+            repository: { owner, name, visibility },
           });
         }
-
-        if (!ref.target.history.pageInfo.hasNextPage) break;
-        cursor = ref.target.history.pageInfo.endCursor;
       }
+
+      if (items.length < EVENTS_FEED_PAGE_SIZE) {
+        feedExhausted = true;
+        break;
+      }
+      // The feed is newest-first: once past --since, older pages are irrelevant.
+      if (oldestSeen !== null && oldestSeen < this.since) break;
+    }
+
+    if (!feedExhausted && oldestSeen !== null && oldestSeen > this.since) {
+      this.onWarning(
+        "The GitHub events feed returns at most 300 events and did not reach --since; some wiki page edits in the range may be missing.",
+      );
     }
 
     return events;

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -99,6 +99,10 @@ const EVENTS_FEED_MAX_PAGES = 3;
 const EVENTS_FEED_PAGE_SIZE = 100;
 const EVENTS_FEED_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
+// With --branches all, a repository with this many branches triggers a
+// heads-up warning about scan time and rate-limit consumption.
+const MANY_BRANCHES_WARNING_THRESHOLD = 200;
+
 // GitHub's Search API never returns more than 1,000 results per query.
 const SEARCH_RESULT_CAP = 1000;
 
@@ -316,8 +320,19 @@ export class GitHubService {
         },
       });
       if (!response.ok) {
+        // The body's message is part of the error so isRetryableError can
+        // recognize secondary rate limits (403 + "rate limit" message) the
+        // same way it does for GraphQL errors; reading it also releases the
+        // connection.
+        const bodyText = await response.text().catch(() => "");
+        let bodyMessage = "";
+        try {
+          bodyMessage = String((JSON.parse(bodyText) as { message?: string }).message ?? "");
+        } catch {
+          bodyMessage = "";
+        }
         const error = new Error(
-          `GitHub REST API request to ${path} failed with status ${String(response.status)}`,
+          `GitHub REST API request to ${path} failed with status ${String(response.status)}${bodyMessage ? `: ${bodyMessage}` : ""}`,
         );
         Object.assign(error, {
           status: response.status,
@@ -821,7 +836,11 @@ export class GitHubService {
         if (!connection) break;
         let reachedOlder = false;
         for (const node of connection.nodes) {
-          if (node.pushedAt === null || new Date(node.pushedAt) < this.since) {
+          // The ordering of never-pushed repositories under PUSHED_AT DESC is
+          // not specified, so a null pushedAt is skipped rather than treated
+          // as an early-stop signal.
+          if (node.pushedAt === null) continue;
+          if (new Date(node.pushedAt) < this.since) {
             reachedOlder = true;
             break;
           }
@@ -914,21 +933,34 @@ export class GitHubService {
     return branches;
   }
 
+  // The commit endpoint returns at most 300 files per page; larger commits
+  // must be paged so no changed file is silently dropped from the audit.
+  private static readonly COMMIT_DIFF_FILES_PER_PAGE = 300;
+
   private async fetchCommitDiff(params: {
     owner: string;
     name: string;
     oid: string;
   }): Promise<CommitDiffFile[]> {
-    const detail = await this.executeRest<RestCommitDetail>(
-      `/repos/${params.owner}/${params.name}/commits/${params.oid}`,
-    );
-    return (detail.files ?? []).map((file) => ({
-      filename: file.filename,
-      status: file.status,
-      additions: file.additions,
-      deletions: file.deletions,
-      patch: file.patch ?? null,
-    }));
+    const basePath = `/repos/${encodeURIComponent(params.owner)}/${encodeURIComponent(params.name)}/commits/${encodeURIComponent(params.oid)}`;
+    const files: CommitDiffFile[] = [];
+
+    for (let page = 1; ; page++) {
+      const detail = await this.executeRest<RestCommitDetail>(`${basePath}?page=${String(page)}`);
+      const pageFiles = detail.files ?? [];
+      files.push(
+        ...pageFiles.map((file) => ({
+          filename: file.filename,
+          status: file.status,
+          additions: file.additions,
+          deletions: file.deletions,
+          patch: file.patch ?? null,
+        })),
+      );
+      if (pageFiles.length < GitHubService.COMMIT_DIFF_FILES_PER_PAGE) break;
+    }
+
+    return files;
   }
 
   private async fetchCommits(username: string): Promise<GitHubEvent[]> {
@@ -944,6 +976,11 @@ export class GitHubService {
       const commitsByOid = new Map<string, { node: CommitHistoryNode; branches: string[] }>();
       const branchNames =
         this.branches === "all" ? await this.listBranches({ owner, name }) : [null];
+      if (branchNames.length > MANY_BRANCHES_WARNING_THRESHOLD) {
+        this.onWarning(
+          `${owner}/${name} has ${String(branchNames.length)} branches; scanning all of them may be slow and consume the API rate limit.`,
+        );
+      }
 
       for (const branch of branchNames) {
         const result = await this.collectBranchHistory({ owner, name, branch, authorId });
@@ -1071,11 +1108,9 @@ export class GitHubService {
           createdAt: node.createdAt,
           description: node.description,
           url: node.url,
-          files: node.files.map((file) => ({
-            name: file.name,
-            size: file.size,
-            text: file.text,
-          })),
+          files: (node.files ?? []).flatMap((file) =>
+            file ? [{ name: file.name, size: file.size, text: file.text }] : [],
+          ),
           repository: {
             owner: username,
             name: node.name,
@@ -1107,15 +1142,21 @@ export class GitHubService {
     for (;;) {
       let reachedOlder = false;
       for (const release of connection.nodes) {
+        // The connection is ordered by creation time, so the early stop must
+        // use createdAt; the range check uses the publication time so a
+        // release drafted earlier still counts from when it went live.
+        // (A release drafted before --since and published inside the range is
+        // missed by the early stop; documented in the README.)
         if (new Date(release.createdAt) < this.since) {
           reachedOlder = true;
           break;
         }
         if (release.author?.login !== username) continue;
-        if (!this.isWithinDateRange(release.createdAt)) continue;
+        const releaseTimestamp = release.publishedAt ?? release.createdAt;
+        if (!this.isWithinDateRange(releaseTimestamp)) continue;
         events.push({
           type: "Release",
-          createdAt: release.createdAt,
+          createdAt: releaseTimestamp,
           title: release.name ?? release.tagName,
           tagName: release.tagName,
           url: release.url,
@@ -1250,7 +1291,7 @@ export class GitHubService {
 
     for (let page = 1; page <= EVENTS_FEED_MAX_PAGES; page++) {
       const items = await this.executeRest<RestUserEvent[]>(
-        `/users/${username}/events?per_page=${String(EVENTS_FEED_PAGE_SIZE)}&page=${String(page)}`,
+        `/users/${encodeURIComponent(username)}/events?per_page=${String(EVENTS_FEED_PAGE_SIZE)}&page=${String(page)}`,
       );
 
       for (const item of items) {

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -2,6 +2,7 @@ import type { ScanConfig } from "./scan.js";
 
 export type Visibility = "public" | "private" | "all";
 export type Order = "asc" | "desc";
+export type Branches = "default" | "all";
 
 export interface CliOptions {
   githubToken: string;
@@ -11,6 +12,10 @@ export interface CliOptions {
   since: Date;
   until: Date;
   visibility: Visibility;
+  /** Collect commits from the default branch only, or from every branch. */
+  branches: Branches;
+  /** When true, attach per-file diffs to Commit events. */
+  commitDiff: boolean;
   maxLengthSize: number;
   maxTokens?: number | undefined;
   order: Order;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -8,7 +8,12 @@ export type GitHubEvent =
   | PullRequestEvent
   | PullRequestCommentEvent
   | PullRequestReviewCommentEvent
-  | CommitEvent;
+  | CommitEvent
+  | CommitCommentEvent
+  | GistEvent
+  | ReleaseEvent
+  | RepositoryEvent
+  | WikiPageEditEvent;
 
 interface BaseEvent {
   type: string;
@@ -18,6 +23,17 @@ interface BaseEvent {
     name: string;
     visibility: RepositoryVisibility;
   };
+}
+
+/**
+ * One prior revision of an edited comment. Present on comment events only
+ * when the comment has been edited, so "deleted right after posting" content
+ * stays auditable.
+ */
+export interface ContentEdit {
+  editedAt: string;
+  deletedAt: string | null;
+  diff: string | null;
 }
 
 export interface IssueEvent extends BaseEvent {
@@ -33,6 +49,7 @@ export interface IssueCommentEvent extends BaseEvent {
   issueUrl: string;
   body: string;
   url: string;
+  editHistory?: ContentEdit[];
 }
 
 export interface DiscussionEvent extends BaseEvent {
@@ -48,6 +65,7 @@ export interface DiscussionCommentEvent extends BaseEvent {
   discussionUrl: string;
   body: string;
   url: string;
+  editHistory?: ContentEdit[];
 }
 
 export interface PullRequestEvent extends BaseEvent {
@@ -63,6 +81,7 @@ export interface PullRequestCommentEvent extends BaseEvent {
   prUrl: string;
   body: string;
   url: string;
+  editHistory?: ContentEdit[];
 }
 
 export interface PullRequestReviewCommentEvent extends BaseEvent {
@@ -71,6 +90,17 @@ export interface PullRequestReviewCommentEvent extends BaseEvent {
   prUrl: string;
   body: string;
   url: string;
+  editHistory?: ContentEdit[];
+}
+
+/** One changed file of a commit, fetched via the REST API with --commit-diff. */
+export interface CommitDiffFile {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  /** Unified diff text; null for binary or oversized files. */
+  patch: string | null;
 }
 
 export interface CommitEvent extends BaseEvent {
@@ -78,4 +108,71 @@ export interface CommitEvent extends BaseEvent {
   message: string;
   url: string;
   oid: string;
+  /** Branches the commit was collected from (the default branch, or every branch with --branches all). */
+  branches: string[];
+  /** Present only with --commit-diff. */
+  diff?: CommitDiffFile[];
+}
+
+export interface CommitCommentEvent extends BaseEvent {
+  type: "CommitComment";
+  body: string;
+  url: string;
+  /** Null when the commented commit is no longer resolvable. */
+  commitOid: string | null;
+  editHistory?: ContentEdit[];
+}
+
+export interface GistFileEntry {
+  name: string;
+  size: number;
+  /** File content; null for binary files. */
+  text: string | null;
+}
+
+/**
+ * A gist created by the user. Gists have no repository; `repository` carries
+ * the gist owner as `owner`, the gist id as `name`, and PUBLIC/PRIVATE for
+ * public/secret gists so the --visibility filter applies uniformly.
+ */
+export interface GistEvent extends BaseEvent {
+  type: "Gist";
+  description: string | null;
+  url: string;
+  files: GistFileEntry[];
+}
+
+export interface ReleaseAssetEntry {
+  name: string;
+  url: string;
+  size: number;
+  contentType: string;
+}
+
+export interface ReleaseEvent extends BaseEvent {
+  type: "Release";
+  title: string;
+  tagName: string;
+  url: string;
+  body: string | null;
+  isPrerelease: boolean;
+  isDraft: boolean;
+  assets: ReleaseAssetEntry[];
+}
+
+/** A repository created by the user within the date range. */
+export interface RepositoryEvent extends BaseEvent {
+  type: "Repository";
+  url: string;
+  description: string | null;
+  isFork: boolean;
+  /** Content of README.md on the default branch, when present. */
+  readme: string | null;
+}
+
+export interface WikiPageEditEvent extends BaseEvent {
+  type: "WikiPageEdit";
+  pageTitle: string;
+  action: string;
+  url: string;
 }

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -224,11 +224,14 @@ export interface GistNode {
   url: string;
   createdAt: string;
   isPublic: boolean;
-  files: {
-    name: string;
-    size: number;
-    text: string | null;
-  }[];
+  /** The list and its entries are nullable in GitHub's schema. */
+  files:
+    | ({
+        name: string;
+        size: number;
+        text: string | null;
+      } | null)[]
+    | null;
 }
 
 export interface GistsResponse {
@@ -263,6 +266,8 @@ export interface ReleaseNode {
   tagName: string;
   url: string;
   createdAt: string;
+  /** Null while the release is an unpublished draft. */
+  publishedAt: string | null;
   description: string | null;
   isPrerelease: boolean;
   isDraft: boolean;

--- a/src/types/github-api.ts
+++ b/src/types/github-api.ts
@@ -34,11 +34,22 @@ export interface IssueNode {
 
 export type IssueSearchResponse = SearchResponse<IssueNode>;
 
+export interface UserContentEditNode {
+  editedAt: string;
+  deletedAt: string | null;
+  diff: string | null;
+}
+
+export interface UserContentEditsConnection {
+  nodes: UserContentEditNode[];
+}
+
 export interface CommentNode {
   body: string;
   url: string;
   createdAt: string;
   author: { login: string } | null;
+  userContentEdits: UserContentEditsConnection | null;
 }
 
 export interface CommentsConnection {
@@ -110,6 +121,7 @@ export interface ReviewNode {
   submittedAt: string | null;
   author: { login: string } | null;
   comments: CommentsConnection;
+  userContentEdits: UserContentEditsConnection | null;
 }
 
 export interface ReviewsConnection {
@@ -173,6 +185,7 @@ export interface CommitHistoryNode {
 export interface CommitHistoryResponse {
   repository: {
     defaultBranchRef: {
+      name: string;
       target: {
         history: {
           pageInfo: PageInfo;
@@ -181,6 +194,177 @@ export interface CommitHistoryResponse {
       };
     } | null;
   };
+}
+
+export interface BranchRefsResponse {
+  repository: {
+    refs: {
+      pageInfo: PageInfo;
+      nodes: { name: string }[];
+    };
+  } | null;
+}
+
+export interface BranchCommitHistoryResponse {
+  repository: {
+    ref: {
+      target: {
+        history: {
+          pageInfo: PageInfo;
+          nodes: CommitHistoryNode[];
+        };
+      } | null;
+    } | null;
+  } | null;
+}
+
+export interface GistNode {
+  name: string;
+  description: string | null;
+  url: string;
+  createdAt: string;
+  isPublic: boolean;
+  files: {
+    name: string;
+    size: number;
+    text: string | null;
+  }[];
+}
+
+export interface GistsResponse {
+  user: {
+    gists: {
+      pageInfo: PageInfo;
+      nodes: GistNode[];
+    };
+  } | null;
+}
+
+export interface CommitCommentNode {
+  body: string;
+  url: string;
+  createdAt: string;
+  commit: { oid: string } | null;
+  repository: RepositoryNode;
+  userContentEdits: UserContentEditsConnection | null;
+}
+
+export interface CommitCommentsResponse {
+  user: {
+    commitComments: {
+      pageInfo: PageInfo;
+      nodes: CommitCommentNode[];
+    };
+  } | null;
+}
+
+export interface ReleaseNode {
+  name: string | null;
+  tagName: string;
+  url: string;
+  createdAt: string;
+  description: string | null;
+  isPrerelease: boolean;
+  isDraft: boolean;
+  author: { login: string } | null;
+  releaseAssets: {
+    nodes: {
+      name: string;
+      downloadUrl: string;
+      size: number;
+      contentType: string;
+    }[];
+  };
+}
+
+export interface ReleasesConnection {
+  pageInfo: PageInfo;
+  nodes: ReleaseNode[];
+}
+
+export interface RepositoryWithReleasesNode {
+  owner: { login: string };
+  name: string;
+  visibility: RepositoryVisibility;
+  releases: ReleasesConnection;
+}
+
+export interface RepositoriesWithReleasesResponse {
+  user: {
+    repositories: {
+      pageInfo: PageInfo;
+      nodes: RepositoryWithReleasesNode[];
+    };
+  } | null;
+}
+
+export interface ReleasesPageResponse {
+  repository: {
+    releases: ReleasesConnection;
+  } | null;
+}
+
+export interface CreatedRepositoryNode {
+  owner: { login: string };
+  name: string;
+  visibility: RepositoryVisibility;
+  url: string;
+  description: string | null;
+  createdAt: string;
+  isFork: boolean;
+  object: { text: string | null } | null;
+}
+
+export interface CreatedRepositoriesResponse {
+  user: {
+    repositories: {
+      pageInfo: PageInfo;
+      nodes: CreatedRepositoryNode[];
+    };
+  } | null;
+}
+
+export interface PushedRepositoryNode {
+  owner: { login: string };
+  name: string;
+  visibility: RepositoryVisibility;
+  pushedAt: string | null;
+}
+
+export interface PushedRepositoriesResponse {
+  user: {
+    repositories: {
+      pageInfo: PageInfo;
+      nodes: PushedRepositoryNode[];
+    };
+  } | null;
+}
+
+/** REST: one item of GET /users/{login}/events (only the fields we read). */
+export interface RestUserEvent {
+  type: string;
+  public: boolean;
+  created_at: string;
+  repo: { name: string };
+  payload: {
+    pages?: {
+      page_name: string;
+      title: string;
+      action: string;
+      html_url: string;
+    }[];
+  };
+}
+
+/** REST: GET /repos/{owner}/{name}/commits/{oid} (only the fields we read). */
+export interface RestCommitDetail {
+  files?: {
+    filename: string;
+    status: string;
+    additions: number;
+    deletions: number;
+    patch?: string;
+  }[];
 }
 
 export interface ViewerResponse {


### PR DESCRIPTION
## Summary

Extends collection with the event types and commit options useful for auditing information leakage on GitHub.

### New event types (always collected, respecting `--visibility`)

- **CommitComment** — comments left directly on commits, via the `user.commitComments` GraphQL connection.
- **Gist** — gists created in range, including file contents; secret gists group with `private`. When the token lacks gist read access (e.g. a fine-grained PAT without the Gists permission), gists are skipped with a warning instead of failing the run.
- **Release** — releases the user published in their **own** repositories (notes + asset metadata); newest-first scan stops at `--since`.
- **Repository** — repositories created in range, with description and README content.
- **WikiPageEdit** — wiki page creates/edits from the REST user events feed (`GollumEvent`). GitHub caps that feed at 90 days / 300 events; warnings are emitted when the range cannot be covered.

### Commit collection options

- `--branches default|all` (default: `default`) — with `all`, every branch is scanned per repository, commits are deduplicated by oid, and each Commit event carries a `branches` list. Repository discovery adds the user's own repositories pushed within the range on top of contribution data.
- `--commit-diff` — attaches per-file diffs (`diff` field) to Commit events via one REST call per commit.
- Commit events now always include a `branches` field (the default branch name in `default` mode).

### Edit histories

Comment events (issue/discussion/PR/review comments, review bodies, commit comments) now carry an `editHistory` field with up to the 5 most recent prior revisions (`userContentEdits`), so content that was posted and then edited or reworded stays auditable. The cap keeps the review search query under GitHub's 500k GraphQL node limit.

### Infrastructure

- A minimal REST client (`executeRest`, global `fetch`, no new dependencies) sharing the existing retry policy, used for commit diffs and the events feed.
- The GraphQL/REST retry loop is unified in `withRetry`.

## Test plan

- Unit tests for each new fetcher (gists incl. permission fallback, commit comments with edit history, releases author/range filtering, created repositories with README, wiki feed parsing, all-branches dedupe with branch lists, commit diffs, issue-comment edit history), plus `--branches`/`--commit-diff` parsing.
- E2E test for invalid `--branches` value.
- `pnpm cicheck` and `pnpm run test:e2e` pass (106 unit tests, 19 E2E tests).
- Live smoke test (`--user dyoshikawa --since 2026-07-28 --branches all --commit-diff`): 406 events collected — 8 Release, 2 Repository (with README), 110 commits all carrying `branches` (98 multi-branch) and `diff`; gist permission fallback and wiki feed warnings both exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)