### PR TITLE
chore: release v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ghactivities",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "",
 	"keywords": [
 		"ai",


### PR DESCRIPTION
Release v1.2.1: bump version in package.json.

See ./tmp/release-notes.md (release notes) — fixes GitHub search RESOURCE_LIMITS_EXCEEDED handling (#62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)