### PR TITLE
feat: add severity-rated risks section to scan prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ npx ghactivities scan ./ghactivities.json --provider openai
 
 ## Scanning activity with an LLM
 
-The `scan` subcommand reads the JSON produced by `ghactivities` and asks a large language model (via the [Vercel AI SDK](https://ai-sdk.dev/)) to summarize your activity into a Markdown report.
+The `scan` subcommand reads the JSON produced by `ghactivities` and asks a large language model (via the [Vercel AI SDK](https://ai-sdk.dev/)) to summarize your activity into a Markdown report. The report covers an overall summary, the main themes grouped by repository, notable items, and a severity-rated **Risks and concerns** section that flags content warranting attention (for example potential secrets in code, diffs, comments, or gists, customer names or internal business information exposed in public repositories, or sensitive information left in comment edit histories).
 
 Note that everything in the collected JSON — comment bodies and edit histories, gist file contents, READMEs, and commit diffs — is sent to the selected LLM provider. Review the collected data (or narrow what you collect) before scanning if it may contain sensitive content.
 

--- a/src/services/scan.ts
+++ b/src/services/scan.ts
@@ -22,12 +22,23 @@ export const MAX_SCAN_INPUT_TOKENS: Record<ScanConfig["provider"], number> = {
 
 const SYSTEM_PROMPT = `You are an assistant that reviews a developer's GitHub activity.
 The user provides a JSON export of their activity (issues, issue comments, discussions,
-discussion comments, pull requests, pull request comments, pull request review comments,
-and commits).
+discussion comments, pull requests, pull request conversation comments, pull request
+review comments, commits, commit comments, gists, releases, repositories, and wiki page
+edits). Commit events may include per-file diffs, and comment events may include an
+editHistory field with prior revisions of the comment.
 Analyze it and produce a concise report in Markdown that includes:
 - A short overall summary of what the developer worked on.
 - The main themes or projects, grouped by repository when useful.
 - Notable pull requests, issues, or discussions worth highlighting.
+- A "Risks and concerns" section listing anything that warrants the developer's
+  attention, each rated with a severity (critical / high / medium / low) — for example
+  potential secrets, credentials, or tokens appearing in code, diffs, comments, or
+  gists; customer names, client project details, or other internal/confidential
+  business information exposed in public repositories; sensitive information visible
+  in comment edit histories; or other content that may need follow-up or removal.
+  Each event carries its repository's visibility — treat exposure in PUBLIC
+  repositories as more severe than the same content in private ones. If there is
+  nothing to report, state that explicitly.
 Be factual and only rely on the provided data.`;
 
 /** Build a Vercel AI SDK language model for the configured provider. */


### PR DESCRIPTION
## Summary

- Update the default `scan` system prompt so the event-type enumeration matches what is actually collected today (commit comments, gists, releases, repositories, wiki page edits, per-file commit diffs, and comment `editHistory`), replacing the outdated 8-type list.
- Add a required **Risks and concerns** section to the report: each finding is rated critical / high / medium / low, covering potential secrets, credentials, or tokens in code, diffs, comments, or gists; customer names, client project details, or other internal/confidential business information exposed in public repositories; and sensitive information left in comment edit histories. Exposure in PUBLIC repositories is weighted as more severe, and the model must state explicitly when there is nothing to report.
- Sync the README's scan section with the new report contents.

## Test plan

- `pnpm cicheck` passes (118 tests, cspell, secretlint).
- Verified end to end by rescanning 22 collected activity chunks (2 years, 2 users) via openrouter: every report now contains a severity-rated Risks and concerns section, and reports with no findings state so explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)